### PR TITLE
Extracting the port allocation requests of Angela through an interface

### DIFF
--- a/agent-lib/src/main/java/org/terracotta/angela/agent/client/RemoteClientManager.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/agent/client/RemoteClientManager.java
@@ -20,6 +20,7 @@ package org.terracotta.angela.agent.client;
 import org.terracotta.angela.agent.Agent;
 import org.terracotta.angela.common.TerracottaCommandLineEnvironment;
 import org.terracotta.angela.common.ToolExecutionResult;
+import org.terracotta.angela.common.net.PortProvider;
 import org.terracotta.angela.common.topology.InstanceId;
 import org.terracotta.angela.common.util.ExternalLoggers;
 import org.terracotta.angela.common.util.JavaLocationResolver;
@@ -41,6 +42,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.terracotta.angela.common.AngelaProperties.DIRECT_JOIN;
 import static org.terracotta.angela.common.AngelaProperties.NODE_NAME;
+import static org.terracotta.angela.common.AngelaProperties.PORT;
 import static org.terracotta.angela.common.AngelaProperties.PORT_RANGE;
 import static org.terracotta.angela.common.AngelaProperties.ROOT_DIR;
 
@@ -91,7 +93,7 @@ public class RemoteClientManager {
     }
   }
 
-  public int spawnClient(InstanceId instanceId, TerracottaCommandLineEnvironment tcEnv, Collection<String> joinedNodes) {
+  public int spawnClient(InstanceId instanceId, TerracottaCommandLineEnvironment tcEnv, Collection<String> joinedNodes, PortProvider portProvider) {
     try {
       String javaHome = javaLocationResolver.resolveJavaLocation(tcEnv).getHome();
 
@@ -108,7 +110,8 @@ public class RemoteClientManager {
       cmdLine.add("-classpath");
       cmdLine.add(buildClasspath());
 
-      cmdLine.add("-D" + PORT_RANGE.getPropertyName() + "=" + PORT_RANGE.getValue());
+      cmdLine.add("-D" + PORT_RANGE.getPropertyName() + "=" + portProvider.getIgnitePortRange());
+      cmdLine.add("-D" + PORT.getPropertyName() + "=" + portProvider.getIgnitePort());
       cmdLine.add("-D" + DIRECT_JOIN.getPropertyName() + "=" + String.join(",", joinedNodes));
       cmdLine.add("-D" + NODE_NAME.getPropertyName() + "=" + instanceId);
       cmdLine.add("-D" + ROOT_DIR.getPropertyName() + "=" + Agent.ROOT_DIR);

--- a/agent-lib/src/main/java/org/terracotta/angela/agent/kit/TerracottaInstall.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/agent/kit/TerracottaInstall.java
@@ -19,6 +19,7 @@ package org.terracotta.angela.agent.kit;
 
 import org.terracotta.angela.common.TerracottaServerInstance;
 import org.terracotta.angela.common.distribution.Distribution;
+import org.terracotta.angela.common.net.PortProvider;
 import org.terracotta.angela.common.tcconfig.License;
 import org.terracotta.angela.common.tcconfig.TerracottaServer;
 import org.terracotta.angela.common.topology.Topology;
@@ -35,10 +36,12 @@ import java.util.UUID;
 public class TerracottaInstall {
 
   private final File rootInstallLocation;
+  private final PortProvider portProvider;
   private final Map<UUID, TerracottaServerInstance> terracottaServerInstances = new HashMap<>();
 
-  public TerracottaInstall(File rootInstallLocation) {
+  public TerracottaInstall(File rootInstallLocation, PortProvider portProvider) {
     this.rootInstallLocation = rootInstallLocation;
+    this.portProvider = portProvider;
   }
 
   public TerracottaServerInstance getTerracottaServerInstance(TerracottaServer terracottaServer) {
@@ -67,7 +70,7 @@ public class TerracottaInstall {
 
   public void addServer(TerracottaServer terracottaServer, File kitLocation, File installLocation, License license, Distribution distribution, Topology topology) {
     synchronized (terracottaServerInstances) {
-      TerracottaServerInstance serverInstance = new TerracottaServerInstance(terracottaServer, kitLocation, installLocation, license, distribution, topology);
+      TerracottaServerInstance serverInstance = new TerracottaServerInstance(terracottaServer, kitLocation, installLocation, license, distribution, topology, portProvider);
       terracottaServerInstances.put(terracottaServer.getId(), serverInstance);
     }
   }

--- a/client-internal/src/main/java/org/terracotta/angela/client/Tsa.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/Tsa.java
@@ -27,6 +27,7 @@ import org.terracotta.angela.common.ConfigToolExecutionResult;
 import org.terracotta.angela.common.TerracottaCommandLineEnvironment;
 import org.terracotta.angela.common.TerracottaServerState;
 import org.terracotta.angela.common.distribution.Distribution;
+import org.terracotta.angela.common.net.PortProvider;
 import org.terracotta.angela.common.provider.ConfigurationManager;
 import org.terracotta.angela.common.provider.DynamicConfigManager;
 import org.terracotta.angela.common.provider.TcConfigManager;
@@ -86,11 +87,11 @@ public class Tsa implements AutoCloseable {
   private final LocalKitManager localKitManager;
   private boolean closed = false;
 
-  Tsa(Ignite ignite, InstanceId instanceId, TsaConfigurationContext tsaConfigurationContext) {
+  Tsa(Ignite ignite, InstanceId instanceId, TsaConfigurationContext tsaConfigurationContext, PortProvider portProvider) {
     this.tsaConfigurationContext = tsaConfigurationContext;
     this.instanceId = instanceId;
     this.ignite = ignite;
-    this.disruptionController = new DisruptionController(ignite, instanceId, tsaConfigurationContext.getTopology());
+    this.disruptionController = new DisruptionController(ignite, instanceId, tsaConfigurationContext.getTopology(), portProvider);
     this.localKitManager = new LocalKitManager(tsaConfigurationContext.getTopology().getDistribution());
     installAll();
   }

--- a/client-internal/src/main/java/org/terracotta/angela/client/remote/agent/NoRemoteAgentLauncher.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/remote/agent/NoRemoteAgentLauncher.java
@@ -17,11 +17,13 @@
 
 package org.terracotta.angela.client.remote.agent;
 
+import org.terracotta.angela.common.net.PortProvider;
+
 import java.util.Collection;
 
 public class NoRemoteAgentLauncher implements RemoteAgentLauncher {
   @Override
-  public void remoteStartAgentOn(String targetServerName, Collection<String> nodesToJoin) {
+  public void remoteStartAgentOn(String targetServerName, Collection<String> nodesToJoin, PortProvider portProvider) {
 
   }
 

--- a/client-internal/src/main/java/org/terracotta/angela/client/remote/agent/RemoteAgentLauncher.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/remote/agent/RemoteAgentLauncher.java
@@ -17,8 +17,10 @@
 
 package org.terracotta.angela.client.remote.agent;
 
+import org.terracotta.angela.common.net.PortProvider;
+
 import java.util.Collection;
 
 public interface RemoteAgentLauncher extends AutoCloseable {
-  void remoteStartAgentOn(String targetServerName, Collection<String> nodesToJoin);
+  void remoteStartAgentOn(String targetServerName, Collection<String> nodesToJoin, PortProvider portProvider);
 }

--- a/client-internal/src/test/java/org/terracotta/angela/client/TsaTest.java
+++ b/client-internal/src/test/java/org/terracotta/angela/client/TsaTest.java
@@ -18,6 +18,7 @@
 package org.terracotta.angela.client;
 
 import org.terracotta.angela.client.config.TsaConfigurationContext;
+import org.terracotta.angela.common.net.PortProvider;
 import org.terracotta.angela.common.tcconfig.License;
 import org.terracotta.angela.common.tcconfig.TcConfig;
 import org.terracotta.angela.common.tcconfig.TerracottaServer;
@@ -50,7 +51,7 @@ public class TsaTest {
     TsaConfigurationContext tsaConfigurationContext = mock(TsaConfigurationContext.class);
     when(tsaConfigurationContext.getTopology()).then(invocationOnMock -> new Topology(distribution(version("3.8.1"), PackageType.KIT, LicenseType.TERRACOTTA_OS), tcConfig));
     when(tsaConfigurationContext.getLicense()).thenReturn(license);
-    Tsa tsa = new Tsa(null, null, tsaConfigurationContext);
+    Tsa tsa = new Tsa(null, null, tsaConfigurationContext, PortProvider.SYS_PROPS);
     List<TerracottaServer> terracottaServerList = new ArrayList<>();
     terracottaServerList.add(TerracottaServer.server("1", "hostname1")
         .tsaPort(9510)
@@ -76,7 +77,7 @@ public class TsaTest {
     TsaConfigurationContext tsaConfigurationContext = mock(TsaConfigurationContext.class);
     when(tsaConfigurationContext.getTopology()).then(invocationOnMock -> new Topology(distribution(version("4.3.6.0.0"), PackageType.KIT, LicenseType.GO), tcConfig));
     when(tsaConfigurationContext.getLicense()).thenReturn(license);
-    Tsa tsa = new Tsa(null, null, tsaConfigurationContext);
+    Tsa tsa = new Tsa(null, null, tsaConfigurationContext, PortProvider.SYS_PROPS);
     List<TerracottaServer> terracottaServerList = new ArrayList<>();
     terracottaServerList.add(TerracottaServer.server("1", "hostname1")
         .tsaPort(9510)

--- a/common/src/main/java/org/terracotta/angela/common/AngelaProperties.java
+++ b/common/src/main/java/org/terracotta/angela/common/AngelaProperties.java
@@ -32,6 +32,7 @@ public enum AngelaProperties {
   DIRECT_JOIN("angela.directJoin", null),
   IGNITE_LOGGING("angela.igniteLogging", "false"),
   NODE_NAME("angela.nodeName", IpUtils.getHostName()),
+  PORT("angela.port", "40000"),
   PORT_RANGE("angela.portRange", "1000"),
   SKIP_KIT_COPY_LOCALHOST("angela.skipKitCopyLocalhost", "true"),
   SKIP_UNINSTALL("angela.skipUninstall", "false"),

--- a/common/src/main/java/org/terracotta/angela/common/TerracottaServerInstance.java
+++ b/common/src/main/java/org/terracotta/angela/common/TerracottaServerInstance.java
@@ -22,6 +22,7 @@ import org.terracotta.angela.common.distribution.DistributionController;
 import org.terracotta.angela.common.net.DisruptionProvider;
 import org.terracotta.angela.common.net.DisruptionProviderFactory;
 import org.terracotta.angela.common.net.Disruptor;
+import org.terracotta.angela.common.net.PortProvider;
 import org.terracotta.angela.common.tcconfig.License;
 import org.terracotta.angela.common.tcconfig.SecurityRootDirectory;
 import org.terracotta.angela.common.tcconfig.ServerSymbolicName;
@@ -56,18 +57,21 @@ public class TerracottaServerInstance implements Closeable {
   private final DistributionController distributionController;
   private final File workingDir;
   private final Distribution distribution;
+  private final PortProvider portProvider;
   private final File licenseFileLocation;
   private volatile TerracottaServerInstanceProcess terracottaServerInstanceProcess;
   private final boolean netDisruptionEnabled;
   private final Topology topology;
 
   public TerracottaServerInstance(TerracottaServer terracottaServer, File kitDir, File workingDir,
-                                  License license, Distribution distribution, Topology topology) {
+                                  License license, Distribution distribution, Topology topology,
+                                  PortProvider portProvider) {
     this.terracottaServer = terracottaServer;
     this.kitDir = kitDir;
     this.distributionController = distribution.createDistributionController();
     this.workingDir = workingDir;
     this.distribution = distribution;
+    this.portProvider = portProvider;
     this.licenseFileLocation = license == null ? null : new File(kitDir, license.getFilename());
     this.netDisruptionEnabled = topology.isNetDisruptionEnabled();
     this.topology = topology;
@@ -77,7 +81,7 @@ public class TerracottaServerInstance implements Closeable {
   private void constructLinks() {
     if (netDisruptionEnabled) {
       topology.getConfigurationManager()
-          .createDisruptionLinks(terracottaServer, DISRUPTION_PROVIDER, disruptionLinks, proxiedPorts);
+          .createDisruptionLinks(terracottaServer, DISRUPTION_PROVIDER, disruptionLinks, proxiedPorts, portProvider);
     }
   }
 

--- a/common/src/main/java/org/terracotta/angela/common/distribution/Distribution43Controller.java
+++ b/common/src/main/java/org/terracotta/angela/common/distribution/Distribution43Controller.java
@@ -106,10 +106,10 @@ public class Distribution43Controller extends DistributionController {
             mr -> stateRef.set(tempStateRef.get()))
         .andTriggerOn(
             compile("^.*\\QServer exiting\\E.*$"),
-            mr -> stateRef.set(STOPPED))
-        .andTriggerOn(
-            tsaFullLogging ? compile("^.*$") : compile("^.*(WARN|ERROR).*$"),
-            mr -> ExternalLoggers.tsaLogger.info("[{}] {}", terracottaServer.getServerSymbolicName().getSymbolicName(), mr.group()));
+            mr -> stateRef.set(STOPPED));
+    serverLogOutputStream = tsaFullLogging ?
+        serverLogOutputStream.andForward(line -> ExternalLoggers.tsaLogger.info("[{}] {}", terracottaServer.getServerSymbolicName().getSymbolicName(), line)) :
+        serverLogOutputStream.andTriggerOn(compile("^.*(WARN|ERROR).*$"), mr -> ExternalLoggers.tsaLogger.info("[{}] {}", terracottaServer.getServerSymbolicName().getSymbolicName(), mr.group()));
 
     // add an identifiable ID to the JVM's system properties
     Map<String, String> env = buildEnv(tcEnv);

--- a/common/src/main/java/org/terracotta/angela/common/net/PortProvider.java
+++ b/common/src/main/java/org/terracotta/angela/common/net/PortProvider.java
@@ -1,0 +1,56 @@
+/*
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Angela.
+ *
+ * The Initial Developer of the Covered Software is
+ * Terracotta, Inc., a Software AG company
+ */
+package org.terracotta.angela.common.net;
+
+import org.terracotta.angela.common.AngelaProperties;
+
+/**
+ * @author Mathieu Carbou
+ */
+public interface PortProvider {
+  PortProvider SYS_PROPS = new PortProvider() {
+    @Override
+    public int getIgnitePort() {
+      return Integer.parseInt(AngelaProperties.PORT.getValue());
+    }
+
+    @Override
+    public int getIgnitePortRange() {
+      return Integer.parseInt(AngelaProperties.PORT_RANGE.getValue());
+    }
+
+    @Override
+    public int getNewRandomFreePort() {
+      return PortChooser.chooseRandomPort();
+    }
+
+    @Override
+    public int getNewRandomFreePorts(int count) {
+      return PortChooser.chooseRandomPorts(count);
+    }
+  };
+
+  int getIgnitePort();
+
+  int getIgnitePortRange();
+
+  default int getNewRandomFreePort() {
+    return getNewRandomFreePorts(1);
+  }
+
+  int getNewRandomFreePorts(int count);
+}

--- a/common/src/main/java/org/terracotta/angela/common/provider/ConfigurationManager.java
+++ b/common/src/main/java/org/terracotta/angela/common/provider/ConfigurationManager.java
@@ -21,6 +21,7 @@ import org.terracotta.angela.common.tcconfig.ServerSymbolicName;
 import org.terracotta.angela.common.tcconfig.TerracottaServer;
 import org.terracotta.angela.common.net.DisruptionProvider;
 import org.terracotta.angela.common.net.Disruptor;
+import org.terracotta.angela.common.net.PortProvider;
 
 import java.util.Collection;
 import java.util.List;
@@ -49,5 +50,6 @@ public interface ConfigurationManager {
   Collection<String> getServersHostnames();
 
   void createDisruptionLinks(TerracottaServer terracottaServer, DisruptionProvider disruptionProvider,
-                             Map<ServerSymbolicName, Disruptor> disruptionLinks, Map<ServerSymbolicName, Integer> proxiedPorts);
+                             Map<ServerSymbolicName, Disruptor> disruptionLinks, Map<ServerSymbolicName, Integer> proxiedPorts,
+                             PortProvider portProvider);
 }

--- a/common/src/main/java/org/terracotta/angela/common/provider/DynamicConfigManager.java
+++ b/common/src/main/java/org/terracotta/angela/common/provider/DynamicConfigManager.java
@@ -20,7 +20,7 @@ package org.terracotta.angela.common.provider;
 import org.terracotta.angela.common.tcconfig.TerracottaServer;
 import org.terracotta.angela.common.net.DisruptionProvider;
 import org.terracotta.angela.common.net.Disruptor;
-import org.terracotta.angela.common.net.PortChooser;
+import org.terracotta.angela.common.net.PortProvider;
 import org.terracotta.angela.common.tcconfig.ServerSymbolicName;
 import org.terracotta.angela.common.dynamic_cluster.Stripe;
 
@@ -154,13 +154,13 @@ public class DynamicConfigManager implements ConfigurationManager {
   public void createDisruptionLinks(TerracottaServer terracottaServer,
                                     DisruptionProvider disruptionProvider,
                                     Map<ServerSymbolicName, Disruptor> disruptionLinks,
-                                    Map<ServerSymbolicName, Integer> proxiedPorts) {
-    PortChooser portChooser = new PortChooser();
+                                    Map<ServerSymbolicName, Integer> proxiedPorts,
+                                    PortProvider portProvider) {
     int stripeIndex = getStripeIndexOf(terracottaServer.getId());
     List<TerracottaServer> allServersInStripe = stripes.get(stripeIndex).getServers();
     for (TerracottaServer server : allServersInStripe) {
       if (!server.getServerSymbolicName().equals(terracottaServer.getServerSymbolicName())) {
-        int tsaRandomGroupPort = portChooser.chooseRandomPort();
+        int tsaRandomGroupPort = portProvider.getNewRandomFreePort();
         final InetSocketAddress src = new InetSocketAddress(terracottaServer.getHostname(), tsaRandomGroupPort);
         final InetSocketAddress dest = new InetSocketAddress(server.getHostname(), server.getTsaGroupPort());
         disruptionLinks.put(server.getServerSymbolicName(), disruptionProvider.createLink(src, dest));

--- a/common/src/main/java/org/terracotta/angela/common/provider/TcConfigManager.java
+++ b/common/src/main/java/org/terracotta/angela/common/provider/TcConfigManager.java
@@ -17,6 +17,7 @@
 
 package org.terracotta.angela.common.provider;
 
+import org.terracotta.angela.common.net.PortProvider;
 import org.terracotta.angela.common.tcconfig.SecurityRootDirectory;
 import org.terracotta.angela.common.tcconfig.ServerSymbolicName;
 import org.terracotta.angela.common.tcconfig.TcConfig;
@@ -204,10 +205,11 @@ public class TcConfigManager implements ConfigurationManager {
   public void createDisruptionLinks(TerracottaServer terracottaServer,
                                     DisruptionProvider disruptionProvider,
                                     Map<ServerSymbolicName, Disruptor> disruptionLinks,
-                                    Map<ServerSymbolicName, Integer> proxiedPorts) {
+                                    Map<ServerSymbolicName, Integer> proxiedPorts,
+                                    PortProvider portProvider) {
     TcConfig tcConfig = findTcConfig(terracottaServer.getId());
     TcConfig modifiedConfig = TcConfig.copy(tcConfig);
-    List<TerracottaServer> members = modifiedConfig.retrieveGroupMembers(terracottaServer.getServerSymbolicName().getSymbolicName(), disruptionProvider.isProxyBased());
+    List<TerracottaServer> members = modifiedConfig.retrieveGroupMembers(terracottaServer.getServerSymbolicName().getSymbolicName(), disruptionProvider.isProxyBased(), portProvider);
     TerracottaServer thisMember = members.get(0);
     for (int i = 1; i < members.size(); ++i) {
       TerracottaServer otherMember = members.get(i);

--- a/common/src/main/java/org/terracotta/angela/common/tcconfig/TcConfig.java
+++ b/common/src/main/java/org/terracotta/angela/common/tcconfig/TcConfig.java
@@ -17,6 +17,7 @@
 
 package org.terracotta.angela.common.tcconfig;
 
+import org.terracotta.angela.common.net.PortProvider;
 import org.terracotta.angela.common.tcconfig.holders.TcConfig10Holder;
 import org.terracotta.angela.common.tcconfig.holders.TcConfig8Holder;
 import org.terracotta.angela.common.tcconfig.holders.TcConfig9Holder;
@@ -161,8 +162,8 @@ public class TcConfig {
     tcConfigHolder.addServer(stripeIndex, hostname);
   }
 
-  public List<TerracottaServer> retrieveGroupMembers(String serverName, boolean updateProxy) {
-    return tcConfigHolder.retrieveGroupMembers(serverName, updateProxy);
+  public List<TerracottaServer> retrieveGroupMembers(String serverName, boolean updateProxy, PortProvider portProvider) {
+    return tcConfigHolder.retrieveGroupMembers(serverName, updateProxy, portProvider);
   }
 
   public void updateServerGroupPort(Map<ServerSymbolicName, Integer> proxiedPorts) {
@@ -173,8 +174,8 @@ public class TcConfig {
     tcConfigHolder.updateServerTsaPort(proxiedPorts);
   }
 
-  public Map<ServerSymbolicName, Integer> retrieveTsaPorts(boolean updateForProxy) {
-    return tcConfigHolder.retrieveTsaPorts(updateForProxy);
+  public Map<ServerSymbolicName, Integer> retrieveTsaPorts(boolean updateForProxy, PortProvider portProvider) {
+    return tcConfigHolder.retrieveTsaPorts(updateForProxy, portProvider);
   }
 
   public void substituteToken(String token, String value) {

--- a/common/src/main/java/org/terracotta/angela/common/tcconfig/holders/TcConfig8Holder.java
+++ b/common/src/main/java/org/terracotta/angela/common/tcconfig/holders/TcConfig8Holder.java
@@ -17,6 +17,7 @@
 
 package org.terracotta.angela.common.tcconfig.holders;
 
+import org.terracotta.angela.common.net.PortProvider;
 import org.terracotta.angela.common.tcconfig.ServerSymbolicName;
 import org.terracotta.angela.common.tcconfig.TerracottaServer;
 import org.terracotta.angela.common.tcconfig.TsaStripeConfig;
@@ -79,12 +80,12 @@ public class TcConfig8Holder extends TcConfigHolder {
   }
 
   @Override
-  public List<TerracottaServer> retrieveGroupMembers(String serverName, boolean updateProxy) {
+  public List<TerracottaServer> retrieveGroupMembers(String serverName, boolean updateProxy, PortProvider portProvider) {
     throw new UnsupportedOperationException("Unimplemented");
   }
 
   @Override
-  public Map<ServerSymbolicName, Integer> retrieveTsaPorts(final boolean updateForProxy) {
+  public Map<ServerSymbolicName, Integer> retrieveTsaPorts(final boolean updateForProxy, PortProvider portProvider) {
     throw new UnsupportedOperationException("Unimplemented");
   }
 

--- a/common/src/main/java/org/terracotta/angela/common/tcconfig/holders/TcConfig9Holder.java
+++ b/common/src/main/java/org/terracotta/angela/common/tcconfig/holders/TcConfig9Holder.java
@@ -17,6 +17,7 @@
 
 package org.terracotta.angela.common.tcconfig.holders;
 
+import org.terracotta.angela.common.net.PortProvider;
 import org.terracotta.angela.common.tcconfig.ServerSymbolicName;
 import org.terracotta.angela.common.tcconfig.TerracottaServer;
 import org.terracotta.angela.common.tcconfig.TsaStripeConfig;
@@ -71,12 +72,12 @@ public class TcConfig9Holder extends TcConfigHolder {
   }
 
   @Override
-  public List<TerracottaServer> retrieveGroupMembers(String serverName, boolean updateProxy) {
+  public List<TerracottaServer> retrieveGroupMembers(String serverName, boolean updateProxy, PortProvider portProvider) {
     throw new UnsupportedOperationException("Unimplemented");
   }
 
   @Override
-  public Map<ServerSymbolicName, Integer> retrieveTsaPorts(final boolean updateForProxy) {
+  public Map<ServerSymbolicName, Integer> retrieveTsaPorts(final boolean updateForProxy, PortProvider portProvider) {
     throw new UnsupportedOperationException("Unimplemented");
   }
 

--- a/common/src/main/java/org/terracotta/angela/common/tcconfig/holders/TcConfigHolder.java
+++ b/common/src/main/java/org/terracotta/angela/common/tcconfig/holders/TcConfigHolder.java
@@ -17,6 +17,7 @@
 
 package org.terracotta.angela.common.tcconfig.holders;
 
+import org.terracotta.angela.common.net.PortProvider;
 import org.terracotta.angela.common.tcconfig.ServerSymbolicName;
 import org.terracotta.angela.common.tcconfig.TerracottaServer;
 import org.terracotta.angela.common.tcconfig.TsaStripeConfig;
@@ -346,13 +347,13 @@ public abstract class TcConfigHolder {
 
   public abstract void updateAuditDirectoryLocation(final File kitDir, final int stripeId);
 
-  public abstract List<TerracottaServer> retrieveGroupMembers(final String serverName, final boolean updateProxy);
+  public abstract List<TerracottaServer> retrieveGroupMembers(final String serverName, final boolean updateProxy, PortProvider portProvider);
 
   public abstract void updateServerGroupPort(Map<ServerSymbolicName, Integer> proxiedPorts);
 
   public abstract void updateServerTsaPort(Map<ServerSymbolicName, Integer> proxiedPorts);
 
-  public abstract Map<ServerSymbolicName, Integer> retrieveTsaPorts(final boolean updateForProxy);
+  public abstract Map<ServerSymbolicName, Integer> retrieveTsaPorts(final boolean updateForProxy, PortProvider portProvider);
 
   public void substituteToken(String token, String value) {
     this.tcConfigContent = this.tcConfigContent.replaceAll(token, value);

--- a/common/src/main/java/org/terracotta/angela/common/util/TriggeringOutputStream.java
+++ b/common/src/main/java/org/terracotta/angela/common/util/TriggeringOutputStream.java
@@ -46,7 +46,18 @@ public class TriggeringOutputStream extends LogOutputStream {
               action.accept(matcher.toMatchResult());
             }
           }
-    });
+        });
+  }
+
+  public final TriggeringOutputStream andForward(Consumer<String> action) {
+    return new TriggeringOutputStream(
+        line -> {
+          try {
+            consumer.accept(line);
+          } finally {
+            action.accept(line);
+          }
+        });
   }
 
   private TriggeringOutputStream(Consumer<String> consumer) {


### PR DESCRIPTION
Commit comment:

_Extracting the port request of Angela through a PortProvider interface.
This interface is implemented by default with the behavior we had in master.
This PR is backward compatible and does not require any change of code form users.
This PR will allow users to provide their own way of reserving ports. 
Typically in tc-platform we want to use the a port locking mechanism that is supporting the
coordination of reserved port across JVM so tha twe can run test concurrently in different spawned JVM._  

This PR exposes through an interface port requests from Angela. This interface can be implemented by tests to provide ports.
This PR is backward compatible.

This is a feature important to have because: the **same** port locking mechanism should be used from the test launcher because when tests are run concurrently, there could be some forked JVM concurrently launching tests.

The port chooser from Angela does not have a cross-jvm coordination for allocated ports.

So extracting an interface is required so that the tests can plugin their own way of controlling port allocation across spawn JVMs (this can be done with the port locking from tc-platform for example)

Use case: https://github.com/Terracotta-OSS/terracotta-platform/pull/679