### PR TITLE
[URG] Revert/Fix commit c1c6ecd33756643c0cb3cabde496c90d1e22594b (PortManager adaption)

### DIFF
--- a/agent-lib/src/main/java/org/terracotta/angela/agent/client/RemoteClientManager.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/agent/client/RemoteClientManager.java
@@ -108,9 +108,9 @@ public class RemoteClientManager {
       cmdLine.add("-classpath");
       cmdLine.add(buildClasspath());
 
-      try (PortAllocator.PortAllocation portAllocation = portAllocator.reserve(2) ) {
-        cmdLine.add("-Dangela.port=" + portAllocation.next());
-      }
+      PortAllocator.PortReservation reservation = portAllocator.reserve(2);
+      cmdLine.add("-Dignite.discovery.port=" + reservation.next());
+      cmdLine.add("-Dignite.com.port=" + reservation.next());
       cmdLine.add("-D" + DIRECT_JOIN.getPropertyName() + "=" + String.join(",", joinedNodes));
       cmdLine.add("-D" + NODE_NAME.getPropertyName() + "=" + instanceId + ":" + ignitePort);
       cmdLine.add("-D" + ROOT_DIR.getPropertyName() + "=" + Agent.ROOT_DIR);

--- a/client-internal/src/main/java/org/terracotta/angela/client/net/DisruptionController.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/net/DisruptionController.java
@@ -65,7 +65,7 @@ public class DisruptionController implements AutoCloseable {
    * Create disruptor to control traffic between all servers specified.
    * (ex: Server1 &lt;-&gt; Server2, Server2 &lt;-&gt; Server3 &amp; Server3 &lt;-&gt; Server1)
    *
-   * @param servers  to be disrupted
+   * @param servers to be disrupted
    * @return {@link ServerToServerDisruptor}
    */
   public ServerToServerDisruptor newServerToServerDisruptor(TerracottaServer... servers) {
@@ -216,10 +216,9 @@ public class DisruptionController implements AutoCloseable {
       } else {
         DynamicConfigManager dynamicConfigManager = (DynamicConfigManager) configurationProvider;
         List<TerracottaServer> servers = dynamicConfigManager.getServers();
-        try (PortAllocator.PortAllocation portAllocation = portAllocator.reserve(servers.size())) {
-          for (TerracottaServer terracottaServer : servers) {
-            proxyTsaPorts.put(terracottaServer.getServerSymbolicName(), portAllocation.next());
-          }
+        PortAllocator.PortReservation reservation = portAllocator.reserve(servers.size());
+        for (TerracottaServer terracottaServer : servers) {
+          proxyTsaPorts.put(terracottaServer.getServerSymbolicName(), reservation.next());
         }
         proxyMap.putAll(proxyTsaPorts);
       }

--- a/client-internal/src/main/java/org/terracotta/angela/client/remote/agent/NoRemoteAgentLauncher.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/remote/agent/NoRemoteAgentLauncher.java
@@ -24,7 +24,7 @@ public class NoRemoteAgentLauncher implements RemoteAgentLauncher {
   }
 
   @Override
-  public void remoteStartAgentOn(String hostname, String nodeName, int ignitePort, String addressesToDiscover) {
+  public void remoteStartAgentOn(String hostname, String nodeName, int igniteDiscoveryPort, int igniteComPort, String addressesToDiscover) {
 
   }
 }

--- a/client-internal/src/main/java/org/terracotta/angela/client/remote/agent/RemoteAgentLauncher.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/remote/agent/RemoteAgentLauncher.java
@@ -19,5 +19,5 @@ package org.terracotta.angela.client.remote.agent;
 
 public interface RemoteAgentLauncher extends AutoCloseable {
 
-  void remoteStartAgentOn(String hostname, String nodeName, int ignitePort, String addressesToDiscover);
+  void remoteStartAgentOn(String hostname, String nodeName, int igniteDiscoveryPort, int igniteComPort, String addressesToDiscover);
 }

--- a/client-internal/src/main/java/org/terracotta/angela/client/remote/agent/SshRemoteAgentLauncher.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/remote/agent/SshRemoteAgentLauncher.java
@@ -105,7 +105,7 @@ public class SshRemoteAgentLauncher implements RemoteAgentLauncher {
   }
 
   @Override
-  public void remoteStartAgentOn(String hostname, String nodeName, int ignitePort, String addressesToDiscover) {
+  public void remoteStartAgentOn(String hostname, String nodeName, int igniteDiscoveryPort, int igniteComPort, String addressesToDiscover) {
     initAgentJar();
     LOGGER.info("spawning {} agent via SSH", hostname);
 
@@ -145,10 +145,10 @@ public class SshRemoteAgentLauncher implements RemoteAgentLauncher {
       Session session = ssh.startSession();
       session.allocateDefaultPTY();
       LOGGER.info("starting agent");
-
       Session.Command cmd = session.exec(remoteJavaHome + "/bin/java " +
           "-D" + NODE_NAME.getPropertyName() + "=" + nodeName + " " +
-          "-Dangela.port=" + ignitePort + " " +
+          "-Dignite.discovery.port=" + igniteDiscoveryPort + " " +
+          "-Dignite.com.port=" + igniteComPort + " " +
           "-D" + DIRECT_JOIN.getPropertyName() + "=" + addressesToDiscover + " " +
           "-D" + ROOT_DIR.getPropertyName() + "=" + baseDir.toString() + " " +
           "-jar " + jarsDir.resolve(agentJarFile.getName()).toString());

--- a/client-internal/src/main/java/org/terracotta/angela/client/support/junit/AngelaRule.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/support/junit/AngelaRule.java
@@ -72,15 +72,15 @@ public class AngelaRule extends ExtendedTestRule {
   protected void before(Description description) throws Throwable {
     final int nodePortCount = computeNodePortCount();
 
-    try (PortAllocator.PortAllocation portAllocation = portAllocator.reserve(nodePortCount)) {
-      // assign generated ports to nodes
-      for (TerracottaServer node : configuration.tsa().getTopology().getServers()) {
-        if (node.getTsaPort() <= 0) {
-          node.tsaPort(portAllocation.next());
-        }
-        if (node.getTsaGroupPort() <= 0) {
-          node.tsaGroupPort(portAllocation.next());
-        }
+    PortAllocator.PortReservation nodePortReservation = portAllocator.reserve(nodePortCount);
+
+    // assign generated ports to nodes
+    for (TerracottaServer node : configuration.tsa().getTopology().getServers()) {
+      if (node.getTsaPort() <= 0) {
+        node.tsaPort(nodePortReservation.next());
+      }
+      if (node.getTsaGroupPort() <= 0) {
+        node.tsaGroupPort(nodePortReservation.next());
       }
     }
 
@@ -110,6 +110,11 @@ public class AngelaRule extends ExtendedTestRule {
         clusterFactory.close();
         clusterFactory = null;
       }
+    } catch (Throwable e) {
+      errs.add(e);
+    }
+    try {
+      portAllocator.close();
     } catch (Throwable e) {
       errs.add(e);
     }

--- a/common/src/main/java/org/terracotta/angela/common/net/PortAllocator.java
+++ b/common/src/main/java/org/terracotta/angela/common/net/PortAllocator.java
@@ -16,17 +16,23 @@
  */
 package org.terracotta.angela.common.net;
 
+import java.io.Closeable;
 import java.util.Iterator;
 
 /**
  * @author Mathieu Carbou
  */
-public interface PortAllocator {
+public interface PortAllocator extends Closeable {
 
-  PortAllocation reserve(int portCounts);
+  PortReservation reserve(int portCounts);
 
-  interface PortAllocation extends AutoCloseable, Iterator<Integer> {
+  @Override
+  default void close() {
+  }
+
+  interface PortReservation extends AutoCloseable, Iterator<Integer> {
     @Override
     void close();
   }
+
 }

--- a/common/src/main/java/org/terracotta/angela/common/provider/DynamicConfigManager.java
+++ b/common/src/main/java/org/terracotta/angela/common/provider/DynamicConfigManager.java
@@ -160,14 +160,11 @@ public class DynamicConfigManager implements ConfigurationManager {
     List<TerracottaServer> allServersInStripe = stripes.get(stripeIndex).getServers();
     for (TerracottaServer server : allServersInStripe) {
       if (!server.getServerSymbolicName().equals(terracottaServer.getServerSymbolicName())) {
-        try (PortAllocator.PortAllocation portAllocation = portAllocator.reserve(1) ) {
-          int tsaRandomGroupPort = portAllocation.next();
-          final InetSocketAddress src = new InetSocketAddress(terracottaServer.getHostname(), tsaRandomGroupPort);
-          final InetSocketAddress dest = new InetSocketAddress(server.getHostname(), server.getTsaGroupPort());
-          disruptionLinks.put(server.getServerSymbolicName(), disruptionProvider.createLink(src, dest));
-          proxiedPorts.put(server.getServerSymbolicName(), src.getPort());
-
-        }
+        int tsaRandomGroupPort = portAllocator.reserve(1).next();
+        final InetSocketAddress src = new InetSocketAddress(terracottaServer.getHostname(), tsaRandomGroupPort);
+        final InetSocketAddress dest = new InetSocketAddress(server.getHostname(), server.getTsaGroupPort());
+        disruptionLinks.put(server.getServerSymbolicName(), disruptionProvider.createLink(src, dest));
+        proxiedPorts.put(server.getServerSymbolicName(), src.getPort());
       }
     }
   }

--- a/common/src/main/java/org/terracotta/angela/common/tcconfig/holders/TcConfig10Holder.java
+++ b/common/src/main/java/org/terracotta/angela/common/tcconfig/holders/TcConfig10Holder.java
@@ -160,11 +160,9 @@ public class TcConfig10Holder extends TcConfigHolder {
         if (name.equals(serverName) || !updateProxy) {
           member = TerracottaServer.server(name, host).tsaGroupPort(groupPort);
         } else {
-          try (PortAllocator.PortAllocation portAllocation = portAllocator.reserve(1) ) {
-            int proxyPort = portAllocation.next();
-            member = TerracottaServer.server(name, host).tsaGroupPort(groupPort).proxyPort(proxyPort);
-            tsaGroupPortNode.setTextContent(String.valueOf(proxyPort));
-          }
+          int proxyPort = portAllocator.reserve(1).next();
+          member = TerracottaServer.server(name, host).tsaGroupPort(groupPort).proxyPort(proxyPort);
+          tsaGroupPortNode.setTextContent(String.valueOf(proxyPort));
         }
         if (name.equals(serverName)) {
           members.add(0, member);
@@ -190,10 +188,8 @@ public class TcConfig10Holder extends TcConfigHolder {
         Node tsaPortNode = (Node) xPath.evaluate("*[name()='tsa-port']", server, XPathConstants.NODE);
         int tsaPort = Integer.parseInt(tsaPortNode.getTextContent().trim());
         if (updateForProxy) {
-          try (PortAllocator.PortAllocation portAllocation = portAllocator.reserve(1) ) {
-            tsaPort = portAllocation.next();
-            tsaPortNode.setTextContent(String.valueOf(tsaPort));
-          }
+          tsaPort = portAllocator.reserve(1).next();
+          tsaPortNode.setTextContent(String.valueOf(tsaPort));
         }
         tsaPorts.put(new ServerSymbolicName(name), tsaPort);
       }


### PR DESCRIPTION
- PortAllocator should be closed globally and keep a hold on all the reserved ports during the whole duration of the test
- try/resource pattern MUST NOT BE USED, otherwise the port reservation will be released before the port is even used
- The new PortManager is randomly picking up ports: there are no consecutive ports anymore

Also other change:
- we shouldn't default ports to 4000 because it leaves the door to someone overriding the ignote ports, which shouldn't be done.