### PR TITLE
Adds a hash suffix to the idPrefix to randomize a little more the dir name in case we run concurrent tests or VM

### DIFF
--- a/client-internal/src/main/java/org/terracotta/angela/client/support/junit/AngelaRule.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/support/junit/AngelaRule.java
@@ -84,7 +84,8 @@ public class AngelaRule extends ExtendedTestRule {
       }
     }
 
-    this.clusterFactory = new ClusterFactory(description.getTestClass().getSimpleName(), configuration);
+    int hash = description.getMethodName() == null ? 0 : description.getMethodName().hashCode();
+    this.clusterFactory = new ClusterFactory(description.getTestClass().getSimpleName() + "-" + hash, configuration);
 
     tsa = memoize(clusterFactory::tsa);
     cluster = memoize(clusterFactory::cluster);


### PR DESCRIPTION
This is a try to solve the random errors we sometimes see:

```
org.terracotta.dynamic_config.server.configuration.nomad.UncheckedNomadException: Exception initializing Nomad Server: java.io.IOException: File lock already held: /data/azure-slave/work/1/s/dynamic-config/testing/system-tests/target/angela/work/SetCommand1x1IT-20200512-014222-0-tsa/node-1-1/config/changes
	at org.terracotta.dynamic_config.server.configuration.service.NomadServerManager.init(NomadServerManager.java:130)
	at org.terracotta.dynamic_config.server.configuration.service.NomadServerManager.init(NomadServerManager.java:116)
	at org.terracotta.dynamic_config.server.configuration.startup.ConfigurationGeneratorVisitor.startUnconfigured(ConfigurationGeneratorVisitor.java:108)
	at org.terracotta.dynamic_config.server.configuration.startup.ConsoleCommandLineProcessor.process(ConsoleCommandLineProcessor.java:59)
	at org.terracotta.dynamic_config.server.configuration.startup.ConfigFileCommandLineProcessor.process(ConfigFileCommandLineProcessor.java:50)
	at org.terracotta.dynamic_config.server.configuration.startup.ConfigRepoCommandLineProcessor.process(ConfigRepoCommandLineProcessor.java:51)
	at org.terracotta.dynamic_config.server.configuration.startup.MainCommandLineProcessor.process(MainCommandLineProcessor.java:43)
	at org.terracotta.dynamic_config.server.configuration.DynamicConfigConfigurationProvider.lambda$initialize$2(DynamicConfigConfigurationProvider.java:111)
	at org.terracotta.dynamic_config.server.configuration.DynamicConfigConfigurationProvider.withMyClassLoader(DynamicConfigConfigurationProvider.java:208)
	at org.terracotta.dynamic_config.server.configuration.DynamicConfigConfigurationProvider.initialize(DynamicConfigConfigurationProvider.java:72)
	at com.tc.server.TCServerMain.main(TCServerMain.java:75)
Caused by: org.terracotta.persistence.sanskrit.SanskritException: java.io.IOException: File lock already held: /data/azure-slave/work/1/s/dynamic-config/testing/system-tests/target/angela/work/SetCommand1x1IT-20200512-014222-0-tsa/node-1-1/config/changes
	at org.terracotta.persistence.sanskrit.Sanskrit.init(Sanskrit.java:43)
	at org.terracotta.dynamic_config.server.configuration.nomad.NomadServerFactory.createServer(NomadServerFactory.java:51)
	at org.terracotta.dynamic_config.server.configuration.service.NomadServerManager.init(NomadServerManager.java:128)
	... 10 more
Caused by: java.io.IOException: File lock already held: /data/azure-slave/work/1/s/dynamic-config/testing/system-tests/target/angela/work/SetCommand1x1IT-20200512-014222-0-tsa/node-1-1/config/changes
	at org.terracotta.persistence.sanskrit.file.lock.FileLockManager.lockOrFail(FileLockManager.java:39)
	at org.terracotta.persistence.sanskrit.file.lock.MuxLockManager.lockOrFail(MuxLockManager.java:42)
	at org.terracotta.persistence.sanskrit.file.FileBasedFilesystemDirectory.lock(FileBasedFilesystemDirectory.java:57)
	at org.terracotta.persistence.sanskrit.Sanskrit.init(Sanskrit.java:33)
```

See: https://github.com/Terracotta-OSS/terracotta-platform/pull/713#issuecomment-627067849