### PR TITLE
Copy kit property

### DIFF
--- a/agent-lib/src/main/java/org/terracotta/angela/agent/kit/RemoteKitManager.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/agent/kit/RemoteKitManager.java
@@ -32,7 +32,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
 
-import static java.lang.Boolean.parseBoolean;
+import static org.terracotta.angela.common.AngelaProperties.KIT_COPY;
 import static org.terracotta.angela.common.AngelaProperties.SKIP_KIT_COPY_LOCALHOST;
 import static org.terracotta.angela.common.util.IpUtils.areAllLocal;
 
@@ -60,8 +60,9 @@ public class RemoteKitManager extends KitManager {
     try {
       Files.createDirectories(workingDir);
 
-      if (areAllLocal(serversHostnames) && parseBoolean(SKIP_KIT_COPY_LOCALHOST.getValue())) {
-        logger.info("Skipped copying kit from {} to {} as all hosts are local", kitInstallationPath.toAbsolutePath(), workingDir);
+      logger.info("TMS should copy a separate kit install ? {}", KIT_COPY.getBooleanValue());
+      if (areAllLocal(serversHostnames) && SKIP_KIT_COPY_LOCALHOST.getBooleanValue() && !KIT_COPY.getBooleanValue()) {
+        logger.info("Skipped copying kit from {} to {}", kitInstallationPath.toAbsolutePath(), workingDir);
         if (license != null) {
           license.writeToFile(kitInstallationPath.toFile());
         }

--- a/client-internal/src/main/java/org/terracotta/angela/client/Client.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/Client.java
@@ -179,7 +179,7 @@ public class Client implements Closeable {
     closed = true;
 
     stop();
-    if (!Boolean.parseBoolean(SKIP_UNINSTALL.getValue())) {
+    if (!SKIP_UNINSTALL.getBooleanValue()) {
       logger.info("Wiping up client '{}' on {}", instanceId, clientId);
       IgniteClientHelper.executeRemotely(ignite, getHostname(), ignitePort, (IgniteRunnable)() -> Agent.controller.deleteClient(instanceId));
     }

--- a/client-internal/src/main/java/org/terracotta/angela/client/ClientArray.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/ClientArray.java
@@ -25,7 +25,6 @@ import org.terracotta.angela.agent.Agent;
 import org.terracotta.angela.agent.kit.LocalKitManager;
 import org.terracotta.angela.client.config.ClientArrayConfigurationContext;
 import org.terracotta.angela.client.filesystem.RemoteFolder;
-import org.terracotta.angela.client.util.IgniteClientHelper;
 import org.terracotta.angela.common.TerracottaCommandLineEnvironment;
 import org.terracotta.angela.common.clientconfig.ClientId;
 import org.terracotta.angela.common.topology.InstanceId;
@@ -44,6 +43,7 @@ import java.util.function.Supplier;
 import static org.terracotta.angela.client.util.IgniteClientHelper.executeRemotely;
 import static org.terracotta.angela.common.AngelaProperties.KIT_INSTALLATION_DIR;
 import static org.terracotta.angela.common.AngelaProperties.KIT_INSTALLATION_PATH;
+import static org.terracotta.angela.common.AngelaProperties.OFFLINE;
 import static org.terracotta.angela.common.AngelaProperties.SKIP_UNINSTALL;
 import static org.terracotta.angela.common.AngelaProperties.getEitherOf;
 
@@ -77,11 +77,9 @@ public class ClientArray implements AutoCloseable {
   }
 
   private void install(ClientId clientId) {
-    boolean offline = Boolean.parseBoolean(System.getProperty("offline", "false"));
-
     logger.info("Setting up locally the extracted install to be deployed remotely");
     String kitInstallationPath = getEitherOf(KIT_INSTALLATION_DIR, KIT_INSTALLATION_PATH);
-    localKitManager.setupLocalInstall(clientArrayConfigurationContext.getLicense(), kitInstallationPath, offline);
+    localKitManager.setupLocalInstall(clientArrayConfigurationContext.getLicense(), kitInstallationPath, OFFLINE.getBooleanValue());
 
     try {
       logger.info("installing the client jars to {}", clientId);
@@ -210,7 +208,7 @@ public class ClientArray implements AutoCloseable {
     }
     closed = true;
 
-    if (!Boolean.parseBoolean(SKIP_UNINSTALL.getValue())) {
+    if (!SKIP_UNINSTALL.getBooleanValue()) {
       uninstallAll();
     }
   }

--- a/client-internal/src/main/java/org/terracotta/angela/client/Tms.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/Tms.java
@@ -167,7 +167,8 @@ public class Tms implements AutoCloseable {
     logger.info("Attempting to remotely install if distribution already exists on {}", tmsHostname);
     IgniteCallable<Boolean> callable = () -> Agent.controller.installTms(instanceId, tmsHostname, distribution, license,
         tmsServerSecurityConfig, localKitManager.getKitInstallationName(), tcEnv, singleton(tmsConfigurationContext.getHostname()));
-    boolean isRemoteInstallationSuccessful = kitInstallationPath == null && IgniteClientHelper.executeRemotely(ignite, tmsHostname, ignitePort, callable);
+    boolean isRemoteInstallationSuccessful = kitInstallationPath == null
+                                             && IgniteClientHelper.executeRemotely(ignite, tmsHostname, ignitePort, callable);
 
     if (!isRemoteInstallationSuccessful) {
       try {

--- a/client-internal/src/main/java/org/terracotta/angela/client/Tms.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/Tms.java
@@ -38,6 +38,7 @@ import org.terracotta.angela.common.util.HostPort;
 import static java.util.Collections.singleton;
 import static org.terracotta.angela.common.AngelaProperties.KIT_INSTALLATION_DIR;
 import static org.terracotta.angela.common.AngelaProperties.KIT_INSTALLATION_PATH;
+import static org.terracotta.angela.common.AngelaProperties.OFFLINE;
 import static org.terracotta.angela.common.AngelaProperties.SKIP_UNINSTALL;
 import static org.terracotta.angela.common.AngelaProperties.getEitherOf;
 
@@ -128,7 +129,7 @@ public class Tms implements AutoCloseable {
       e.printStackTrace();
       // ignore, not installed
     }
-    if (!Boolean.parseBoolean(SKIP_UNINSTALL.getValue())) {
+    if (!SKIP_UNINSTALL.getBooleanValue()) {
       uninstall();
     }
   }
@@ -158,11 +159,10 @@ public class Tms implements AutoCloseable {
     TerracottaCommandLineEnvironment tcEnv = tmsConfigurationContext.getTerracottaCommandLineEnvironment();
 
     logger.info("starting TMS on {}", tmsHostname);
-    boolean offline = Boolean.parseBoolean(System.getProperty("offline", "false"));
 
     logger.debug("Setting up locally the extracted install to be deployed remotely");
     String kitInstallationPath = getEitherOf(KIT_INSTALLATION_DIR, KIT_INSTALLATION_PATH);
-    localKitManager.setupLocalInstall(license, kitInstallationPath, offline);
+    localKitManager.setupLocalInstall(license, kitInstallationPath, OFFLINE.getBooleanValue());
 
     logger.info("Attempting to remotely install if distribution already exists on {}", tmsHostname);
     IgniteCallable<Boolean> callable = () -> Agent.controller.installTms(instanceId, tmsHostname, distribution, license,

--- a/client-internal/src/main/java/org/terracotta/angela/client/Tsa.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/Tsa.java
@@ -62,6 +62,7 @@ import java.util.stream.Collectors;
 import static java.util.EnumSet.of;
 import static org.terracotta.angela.common.AngelaProperties.KIT_INSTALLATION_DIR;
 import static org.terracotta.angela.common.AngelaProperties.KIT_INSTALLATION_PATH;
+import static org.terracotta.angela.common.AngelaProperties.OFFLINE;
 import static org.terracotta.angela.common.AngelaProperties.SKIP_KIT_INSTALL;
 import static org.terracotta.angela.common.AngelaProperties.SKIP_UNINSTALL;
 import static org.terracotta.angela.common.AngelaProperties.getEitherOf;
@@ -147,14 +148,13 @@ public class Tsa implements AutoCloseable {
     }
     Distribution distribution = localKitManager.getDistribution();
 
-    boolean offline = Boolean.parseBoolean(System.getProperty("offline", "false"));
     License license = tsaConfigurationContext.getLicense();
 
     String kitInstallationPath = getEitherOf(KIT_INSTALLATION_DIR, KIT_INSTALLATION_PATH);
-    localKitManager.setupLocalInstall(license, kitInstallationPath, offline);
+    localKitManager.setupLocalInstall(license, kitInstallationPath, OFFLINE.getBooleanValue());
 
     boolean isRemoteInstallationSuccessful;
-    if (kitInstallationPath == null || Boolean.parseBoolean(SKIP_KIT_INSTALL.getValue())) {
+    if (kitInstallationPath == null || SKIP_KIT_INSTALL.getBooleanValue()) {
       logger.info("Attempting to remotely install if distribution already exists on {}", terracottaServer.getHostname());
       isRemoteInstallationSuccessful = IgniteClientHelper.executeRemotely(ignite, terracottaServer.getHostname(), ignitePort,
           () -> Agent.controller.installTsa(instanceId, terracottaServer,
@@ -819,7 +819,7 @@ public class Tsa implements AutoCloseable {
     closed = true;
 
     stopAll();
-    if (!Boolean.parseBoolean(SKIP_UNINSTALL.getValue())) {
+    if (!SKIP_UNINSTALL.getBooleanValue()) {
       uninstallAll();
     }
 

--- a/client-internal/src/main/java/org/terracotta/angela/client/Voter.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/Voter.java
@@ -39,6 +39,7 @@ import java.util.concurrent.CompletableFuture;
 
 import static org.terracotta.angela.common.AngelaProperties.KIT_INSTALLATION_DIR;
 import static org.terracotta.angela.common.AngelaProperties.KIT_INSTALLATION_PATH;
+import static org.terracotta.angela.common.AngelaProperties.OFFLINE;
 import static org.terracotta.angela.common.AngelaProperties.SKIP_UNINSTALL;
 import static org.terracotta.angela.common.AngelaProperties.getEitherOf;
 
@@ -122,7 +123,7 @@ public class Voter implements AutoCloseable {
     closed = true;
 
     stopAll();
-    if (!Boolean.parseBoolean(SKIP_UNINSTALL.getValue())) {
+    if (!SKIP_UNINSTALL.getBooleanValue()) {
       uninstallAll();
     }
   }
@@ -142,10 +143,9 @@ public class Voter implements AutoCloseable {
     TerracottaCommandLineEnvironment tcEnv = voterConfigurationContext.getTerracottaCommandLineEnvironment();
 
     logger.info("starting voter on {}", terracottaVoter.getHostName());
-    boolean offline = Boolean.parseBoolean(System.getProperty("offline", "false"));
 
     String kitInstallationPath = getEitherOf(KIT_INSTALLATION_DIR, KIT_INSTALLATION_PATH);
-    localKitManager.setupLocalInstall(license, kitInstallationPath, offline);
+    localKitManager.setupLocalInstall(license, kitInstallationPath, OFFLINE.getBooleanValue());
 
     IgniteCallable<Boolean> callable = () -> Agent.controller.installVoter(instanceId, terracottaVoter, distribution, license,
         localKitManager.getKitInstallationName(), tcEnv);

--- a/client-internal/src/main/java/org/terracotta/angela/client/remote/agent/SshRemoteAgentLauncher.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/remote/agent/SshRemoteAgentLauncher.java
@@ -113,7 +113,7 @@ public class SshRemoteAgentLauncher implements RemoteAgentLauncher {
       SSHClient ssh = new SSHClient();
       final String angelaHome = ".angela/" + hostname;
 
-      if (!Boolean.parseBoolean(SSH_STRICT_HOST_CHECKING.getValue())) {
+      if (!SSH_STRICT_HOST_CHECKING.getBooleanValue()) {
         ssh.addHostKeyVerifier(new PromiscuousVerifier());
       }
       ssh.loadKnownHosts();

--- a/common/src/main/java/org/terracotta/angela/common/AngelaProperties.java
+++ b/common/src/main/java/org/terracotta/angela/common/AngelaProperties.java
@@ -27,28 +27,54 @@ import java.nio.file.Paths;
  * Listing of all system properties supported in angela
  */
 public enum AngelaProperties {
+  // root dir where Angela puts installation, work directories and any file that is needed
   ROOT_DIR("angela.rootDir", Paths.get("/data/angela").toAbsolutePath().toString()),
+  // shortcut for angela.rootDir property above
+  KITS_DIR("kitsDir", Paths.get("/data/angela").toAbsolutePath().toString()),
+
+  // use this property to use a local build instead of downloading a kit build
   KIT_INSTALLATION_DIR("angela.kitInstallationDir", null),
+
+  // same as angela.kitInstallationDir, used for compatibility with Galvan
+  KIT_INSTALLATION_PATH("kitInstallationPath", null),
+
+  // ?
   SKIP_KIT_INSTALL("angela.skipKitInstall", "false"),
-  DIRECT_JOIN("angela.directJoin", ""),
-  IGNITE_LOGGING("angela.igniteLogging", "false"),
-  NODE_NAME("angela.nodeName", IpUtils.getHostName()),
+
+  // ?
   SKIP_KIT_COPY_LOCALHOST("angela.skipKitCopyLocalhost", "true"),
+
+  // ?
+  DISTRIBUTION("angela.distribution", null),
+
+  // display Ignite logging (used to help debugging the behaviour of Angela)
+  IGNITE_LOGGING("angela.igniteLogging", "false"),
+
+  // do not clean work directory (used to have access to logs after end of test for debugging test issues)
   SKIP_UNINSTALL("angela.skipUninstall", "false"),
+
+  // forces a kit copy instead of using a common kit install for multiple tests. useful for parallel execution of tests
+  //   that changes files in the kit install (e.g. tmc.properties)
+  KIT_COPY("angela.kitCopy", "false"),
+
+  // ssh properties
   SSH_USERNAME("angela.ssh.userName", System.getProperty("user.name")),
   SSH_USERNAME_KEY_PATH("angela.ssh.userName.keyPath", null),
   SSH_STRICT_HOST_CHECKING("angela.ssh.strictHostKeyChecking", "true"),
+
+  // logging properties
   TMS_FULL_LOGGING("angela.tms.fullLogging", "false"),
   TSA_FULL_LOGGING("angela.tsa.fullLogging", "false"),
   VOTER_FULL_LOGGING("angela.voter.fullLogging", "false"),
+
+  // jdk properties to be used by Angela for running processes
   JAVA_VENDOR("angela.java.vendor", "zulu"),
   JAVA_VERSION("angela.java.version", "1.8"),
   JAVA_OPTS("angela.java.opts", "-Djdk.security.allowNonCaAnchor=false"),
-  DISTRIBUTION("angela.distribution", null),
 
-  // Deprecated properties
-  KITS_DIR("kitsDir", Paths.get("/data/angela").toAbsolutePath().toString()),
-  KIT_INSTALLATION_PATH("kitInstallationPath", null),
+  // internal properties
+  DIRECT_JOIN("angela.directJoin", ""),
+  NODE_NAME("angela.nodeName", IpUtils.getHostName()),
   ;
 
   private static final Logger logger = LoggerFactory.getLogger(AngelaProperties.class);
@@ -108,5 +134,9 @@ public enum AngelaProperties {
       value = recommended.getDefaultValue();
     }
     return value;
+  }
+
+  public boolean getBooleanValue() {
+    return Boolean.parseBoolean(getValue());
   }
 }

--- a/common/src/main/java/org/terracotta/angela/common/AngelaProperties.java
+++ b/common/src/main/java/org/terracotta/angela/common/AngelaProperties.java
@@ -38,6 +38,9 @@ public enum AngelaProperties {
   // same as angela.kitInstallationDir, used for compatibility with Galvan
   KIT_INSTALLATION_PATH("kitInstallationPath", null),
 
+  // running the test offline (no network connection)
+  OFFLINE("angela.offline", "false"),
+
   // ?
   SKIP_KIT_INSTALL("angela.skipKitInstall", "false"),
 

--- a/common/src/main/java/org/terracotta/angela/common/distribution/Distribution102Controller.java
+++ b/common/src/main/java/org/terracotta/angela/common/distribution/Distribution102Controller.java
@@ -77,8 +77,8 @@ import static org.terracotta.angela.common.util.HostAndIpValidator.isValidIPv6;
  */
 public class Distribution102Controller extends DistributionController {
   private final static Logger logger = LoggerFactory.getLogger(Distribution102Controller.class);
-  private final boolean tsaFullLogging = Boolean.parseBoolean(AngelaProperties.TSA_FULL_LOGGING.getValue());
-  private final boolean tmsFullLogging = Boolean.parseBoolean(AngelaProperties.TMS_FULL_LOGGING.getValue());
+  private final boolean tsaFullLogging = AngelaProperties.TSA_FULL_LOGGING.getBooleanValue();
+  private final boolean tmsFullLogging = AngelaProperties.TMS_FULL_LOGGING.getBooleanValue();
 
   Distribution102Controller(Distribution distribution) {
     super(distribution);

--- a/common/src/main/java/org/terracotta/angela/common/distribution/Distribution107Controller.java
+++ b/common/src/main/java/org/terracotta/angela/common/distribution/Distribution107Controller.java
@@ -25,10 +25,10 @@ import org.terracotta.angela.common.TerracottaCommandLineEnvironment;
 import org.terracotta.angela.common.TerracottaManagementServerInstance.TerracottaManagementServerInstanceProcess;
 import org.terracotta.angela.common.TerracottaManagementServerState;
 import org.terracotta.angela.common.TerracottaServerInstance.TerracottaServerInstanceProcess;
-import org.terracotta.angela.common.TerracottaVoterState;
+import org.terracotta.angela.common.TerracottaServerState;
 import org.terracotta.angela.common.TerracottaVoter;
 import org.terracotta.angela.common.TerracottaVoterInstance;
-import org.terracotta.angela.common.TerracottaServerState;
+import org.terracotta.angela.common.TerracottaVoterState;
 import org.terracotta.angela.common.tcconfig.SecurityRootDirectory;
 import org.terracotta.angela.common.tcconfig.ServerSymbolicName;
 import org.terracotta.angela.common.tcconfig.TerracottaServer;
@@ -65,9 +65,9 @@ import static org.terracotta.angela.common.AngelaProperties.VOTER_FULL_LOGGING;
 
 public class Distribution107Controller extends DistributionController {
   private final static Logger LOGGER = LoggerFactory.getLogger(Distribution107Controller.class);
-  private final boolean tsaFullLogging = Boolean.parseBoolean(TSA_FULL_LOGGING.getValue());
-  private final boolean tmsFullLogging = Boolean.parseBoolean(TMS_FULL_LOGGING.getValue());
-  private final boolean voterFullLogging = Boolean.parseBoolean(VOTER_FULL_LOGGING.getValue());
+  private final boolean tsaFullLogging = TSA_FULL_LOGGING.getBooleanValue();
+  private final boolean tmsFullLogging = TMS_FULL_LOGGING.getBooleanValue();
+  private final boolean voterFullLogging = VOTER_FULL_LOGGING.getBooleanValue();
 
   public Distribution107Controller(Distribution distribution) {
     super(distribution);

--- a/common/src/main/java/org/terracotta/angela/common/distribution/Distribution43Controller.java
+++ b/common/src/main/java/org/terracotta/angela/common/distribution/Distribution43Controller.java
@@ -17,14 +17,17 @@
 
 package org.terracotta.angela.common.distribution;
 
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terracotta.angela.common.ClusterToolExecutionResult;
 import org.terracotta.angela.common.ConfigToolExecutionResult;
 import org.terracotta.angela.common.TerracottaCommandLineEnvironment;
 import org.terracotta.angela.common.TerracottaManagementServerInstance.TerracottaManagementServerInstanceProcess;
 import org.terracotta.angela.common.TerracottaServerInstance.TerracottaServerInstanceProcess;
+import org.terracotta.angela.common.TerracottaServerState;
 import org.terracotta.angela.common.TerracottaVoter;
 import org.terracotta.angela.common.TerracottaVoterInstance;
-import org.terracotta.angela.common.TerracottaServerState;
 import org.terracotta.angela.common.provider.ConfigurationManager;
 import org.terracotta.angela.common.provider.TcConfigManager;
 import org.terracotta.angela.common.tcconfig.SecurityRootDirectory;
@@ -37,9 +40,6 @@ import org.terracotta.angela.common.util.ExternalLoggers;
 import org.terracotta.angela.common.util.HostPort;
 import org.terracotta.angela.common.util.OS;
 import org.terracotta.angela.common.util.TriggeringOutputStream;
-import org.apache.commons.io.FileUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zeroturnaround.exec.ProcessExecutor;
 import org.zeroturnaround.exec.ProcessResult;
 
@@ -56,6 +56,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static java.io.File.separator;
+import static java.util.regex.Pattern.compile;
 import static org.terracotta.angela.common.AngelaProperties.TSA_FULL_LOGGING;
 import static org.terracotta.angela.common.TerracottaServerState.STARTED_AS_ACTIVE;
 import static org.terracotta.angela.common.TerracottaServerState.STARTED_AS_PASSIVE;
@@ -65,8 +67,6 @@ import static org.terracotta.angela.common.topology.PackageType.SAG_INSTALLER;
 import static org.terracotta.angela.common.util.HostAndIpValidator.isValidHost;
 import static org.terracotta.angela.common.util.HostAndIpValidator.isValidIPv4;
 import static org.terracotta.angela.common.util.HostAndIpValidator.isValidIPv6;
-import static java.io.File.separator;
-import static java.util.regex.Pattern.compile;
 
 /**
  * @author Aurelien Broszniowski
@@ -74,7 +74,7 @@ import static java.util.regex.Pattern.compile;
 public class Distribution43Controller extends DistributionController {
   private final static Logger logger = LoggerFactory.getLogger(Distribution43Controller.class);
 
-  private final boolean tsaFullLogging = Boolean.parseBoolean(TSA_FULL_LOGGING.getValue());
+  private final boolean tsaFullLogging = TSA_FULL_LOGGING.getBooleanValue();
 
   Distribution43Controller(Distribution distribution) {
     super(distribution);


### PR DESCRIPTION
Add property to force kit copy in the work dir (original behaviour) when running parallel tests that use/modify files located in the kit (e.g. tmc.properties)