### PR TITLE
Throws an exception in case of a tool error

### DIFF
--- a/common/src/main/java/org/terracotta/angela/common/distribution/Distribution102Controller.java
+++ b/common/src/main/java/org/terracotta/angela/common/distribution/Distribution102Controller.java
@@ -157,6 +157,7 @@ public class Distribution102Controller extends DistributionController {
           .environment(buildEnv(tcEnv))
           .readOutput(true)
           .redirectErrorStream(true)
+          .exitValue(0)
           .execute();
       return new ClusterToolExecutionResult(processResult.getExitValue(), processResult.getOutput().getLines());
     } catch (Exception e) {

--- a/common/src/main/java/org/terracotta/angela/common/distribution/Distribution107Controller.java
+++ b/common/src/main/java/org/terracotta/angela/common/distribution/Distribution107Controller.java
@@ -257,6 +257,7 @@ public class Distribution107Controller extends DistributionController {
           .readOutput(true)
           .redirectOutputAlsoTo(Slf4jStream.of(ExternalLoggers.clusterToolLogger).asInfo())
           .redirectErrorStream(true)
+          .exitValue(0)
           .execute();
       return new ClusterToolExecutionResult(processResult.getExitValue(), processResult.getOutput().getLines());
     } catch (Exception e) {
@@ -273,6 +274,7 @@ public class Distribution107Controller extends DistributionController {
           .readOutput(true)
           .redirectOutputAlsoTo(Slf4jStream.of(ExternalLoggers.configToolLogger).asInfo())
           .redirectErrorStream(true)
+          .exitValue(0)
           .execute();
       return new ConfigToolExecutionResult(processResult.getExitValue(), processResult.getOutput().getLines());
     } catch (Exception e) {

--- a/integration-test/src/test/java/org/terracotta/angela/ConfigToolTest.java
+++ b/integration-test/src/test/java/org/terracotta/angela/ConfigToolTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2011-2020 Software AG, Darmstadt, Germany and/or Software AG USA Inc., Reston, VA, USA, and/or its subsidiaries and/or its affiliates and/or their licensors.
+ * Use, reproduction, transfer, publication or disclosure is prohibited except as specifically provided for in your License Agreement with Software AG.
+ */
+
+package org.terracotta.angela;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terracotta.angela.client.ClusterFactory;
+import org.terracotta.angela.client.ConfigTool;
+import org.terracotta.angela.client.Tsa;
+import org.terracotta.angela.client.config.ConfigurationContext;
+import org.terracotta.angela.common.topology.Topology;
+
+import java.time.Duration;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.fail;
+import static org.terracotta.angela.client.config.custom.CustomConfigurationContext.customConfigurationContext;
+import static org.terracotta.angela.common.distribution.Distribution.distribution;
+import static org.terracotta.angela.common.dynamic_cluster.Stripe.stripe;
+import static org.terracotta.angela.common.provider.DynamicConfigManager.dynamicCluster;
+import static org.terracotta.angela.common.tcconfig.TerracottaServer.server;
+import static org.terracotta.angela.common.topology.LicenseType.TERRACOTTA_OS;
+import static org.terracotta.angela.common.topology.PackageType.KIT;
+import static org.terracotta.angela.common.topology.Version.version;
+
+/**
+ * @author Yakov Feldman
+ */
+public class ConfigToolTest {
+  private final static Logger logger = LoggerFactory.getLogger(ConfigToolTest.class);
+
+  @Test
+  public void testFailingClusterToolCommand() throws Exception {
+    ConfigurationContext configContext = customConfigurationContext()
+        .tsa(tsa -> tsa
+            .topology(
+                new Topology(
+                    distribution(version("3.9-SNAPSHOT"), KIT, TERRACOTTA_OS),
+                    dynamicCluster(
+                        stripe(
+                            server("server-1", "localhost")
+                                .tsaPort(9410)
+                                .tsaGroupPort(9411)
+                                .configRepo("terracotta1/repository")
+                                .logs("terracotta1/logs")
+                                .metaData("terracotta1/metadata")
+                                .failoverPriority("availability")
+                        )
+                    )
+                )
+            )
+        );
+
+    try (ClusterFactory factory = new ClusterFactory("ConfigToolTest::testFailingClusterToolCommand", configContext)) {
+      Tsa tsa = factory.tsa();
+      tsa.startAll().attachAll().activateAll();
+
+      await().atMost(Duration.ofSeconds(60)).until(() -> tsa.getTsaConfigurationContext().getTopology().getStripes().size(), is(1));
+
+      ConfigTool configTool = tsa.configTool(tsa.getActive());
+
+      try {
+        configTool.executeCommand("fail");
+        fail("cluster tool should fail because the license path doesn't exist");
+      } catch (Exception e) {
+        // expected
+      }
+    }
+  }
+}

--- a/integration-test/src/test/java/org/terracotta/angela/ConfigToolTest.java
+++ b/integration-test/src/test/java/org/terracotta/angela/ConfigToolTest.java
@@ -1,8 +1,19 @@
 /*
- * Copyright (c) 2011-2020 Software AG, Darmstadt, Germany and/or Software AG USA Inc., Reston, VA, USA, and/or its subsidiaries and/or its affiliates and/or their licensors.
- * Use, reproduction, transfer, publication or disclosure is prohibited except as specifically provided for in your License Agreement with Software AG.
+ * The contents of this file are subject to the Terracotta Public License Version
+ * 2.0 (the "License"); You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://terracotta.org/legal/terracotta-public-license.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+ * the specific language governing rights and limitations under the License.
+ *
+ * The Covered Software is Angela.
+ *
+ * The Initial Developer of the Covered Software is
+ * Terracotta, Inc., a Software AG company
  */
-
 package org.terracotta.angela;
 
 import org.junit.Test;

--- a/integration-test/src/test/java/org/terracotta/angela/ConfigToolTest.java
+++ b/integration-test/src/test/java/org/terracotta/angela/ConfigToolTest.java
@@ -25,10 +25,6 @@ import org.terracotta.angela.client.Tsa;
 import org.terracotta.angela.client.config.ConfigurationContext;
 import org.terracotta.angela.common.topology.Topology;
 
-import java.time.Duration;
-
-import static org.awaitility.Awaitility.await;
-import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.fail;
 import static org.terracotta.angela.client.config.custom.CustomConfigurationContext.customConfigurationContext;
 import static org.terracotta.angela.common.distribution.Distribution.distribution;
@@ -39,14 +35,11 @@ import static org.terracotta.angela.common.topology.LicenseType.TERRACOTTA_OS;
 import static org.terracotta.angela.common.topology.PackageType.KIT;
 import static org.terracotta.angela.common.topology.Version.version;
 
-/**
- * @author Yakov Feldman
- */
 public class ConfigToolTest {
   private final static Logger logger = LoggerFactory.getLogger(ConfigToolTest.class);
 
   @Test
-  public void testFailingClusterToolCommand() throws Exception {
+  public void testFailingConfigToolCommand() throws Exception {
     ConfigurationContext configContext = customConfigurationContext()
         .tsa(tsa -> tsa
             .topology(
@@ -69,15 +62,13 @@ public class ConfigToolTest {
 
     try (ClusterFactory factory = new ClusterFactory("ConfigToolTest::testFailingClusterToolCommand", configContext)) {
       Tsa tsa = factory.tsa();
-      tsa.startAll().attachAll().activateAll();
-
-      await().atMost(Duration.ofSeconds(60)).until(() -> tsa.getTsaConfigurationContext().getTopology().getStripes().size(), is(1));
+      tsa.startAll().activateAll();
 
       ConfigTool configTool = tsa.configTool(tsa.getActive());
 
       try {
-        configTool.executeCommand("fail");
-        fail("config tool should fail because the option doesn't exist");
+        configTool.executeCommand("non-existent-command");
+        fail("Expected config tool invocation to fail as the command doesn't exist");
       } catch (Exception e) {
         // expected
       }

--- a/integration-test/src/test/java/org/terracotta/angela/ConfigToolTest.java
+++ b/integration-test/src/test/java/org/terracotta/angela/ConfigToolTest.java
@@ -77,7 +77,7 @@ public class ConfigToolTest {
 
       try {
         configTool.executeCommand("fail");
-        fail("cluster tool should fail because the license path doesn't exist");
+        fail("config tool should fail because the option doesn't exist");
       } catch (Exception e) {
         // expected
       }


### PR DESCRIPTION
Currently, a failure from the config tool or the cluster tool are logged but not propagated from Angela to the tests.
Therefore some tests are not failing while they should.
This PR fixes this.
Warning : There might be some existing tests in other projects that were not failing so far and would be failing (which is the correct behaviour) with the new release of Angela after merging this PR.