### PR TITLE
Fixes

### DIFF
--- a/agent-lib/src/main/java/org/terracotta/angela/agent/AgentController.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/agent/AgentController.java
@@ -17,7 +17,6 @@
 
 package org.terracotta.angela.agent;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.ignite.Ignite;
 import org.slf4j.Logger;
@@ -51,6 +50,7 @@ import org.terracotta.angela.common.tms.security.config.TmsServerSecurityConfig;
 import org.terracotta.angela.common.topology.InstanceId;
 import org.terracotta.angela.common.topology.Topology;
 import org.terracotta.angela.common.util.FileMetadata;
+import org.terracotta.angela.common.util.FileUtils;
 import org.terracotta.angela.common.util.IgniteCommonHelper;
 import org.terracotta.angela.common.util.ProcessUtil;
 
@@ -557,8 +557,8 @@ public class AgentController {
   public void deleteClient(InstanceId instanceId) {
     try {
       File subAgentRoot = new RemoteClientManager(instanceId).getClientInstallationPath();
-      logger.info("cleaning up directory structure '{}' of client {}", subAgentRoot, instanceId);
-      FileUtils.deleteDirectory(subAgentRoot);
+      logger.info("Cleaning up directory structure '{}' of client {}", subAgentRoot, instanceId);
+      FileUtils.deleteDirectory(subAgentRoot.toPath());
     } catch (Exception e) {
       throw new RuntimeException("Error deleting client " + instanceId, e);
     }

--- a/agent-lib/src/main/java/org/terracotta/angela/agent/kit/RemoteKitManager.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/agent/kit/RemoteKitManager.java
@@ -17,7 +17,6 @@
 
 package org.terracotta.angela.agent.kit;
 
-import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terracotta.angela.agent.Agent;
@@ -25,6 +24,7 @@ import org.terracotta.angela.common.distribution.Distribution;
 import org.terracotta.angela.common.tcconfig.License;
 import org.terracotta.angela.common.topology.InstanceId;
 import org.terracotta.angela.common.util.DirectoryUtils;
+import org.terracotta.angela.common.util.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -94,7 +94,7 @@ public class RemoteKitManager extends KitManager {
   }
 
   public void deleteInstall(File installLocation) throws IOException {
-    logger.info("deleting installation in {}", installLocation.getAbsolutePath());
-    FileUtils.deleteDirectory(installLocation);
+    logger.info("Deleting installation in {}", installLocation.getAbsolutePath());
+    FileUtils.deleteDirectory(installLocation.toPath());
   }
 }

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -55,6 +55,10 @@
       <artifactId>commons-compress</artifactId>
     </dependency>
     <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/common/src/main/java/org/terracotta/angela/common/distribution/Distribution102Controller.java
+++ b/common/src/main/java/org/terracotta/angela/common/distribution/Distribution102Controller.java
@@ -17,7 +17,6 @@
 
 package org.terracotta.angela.common.distribution;
 
-import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terracotta.angela.common.AngelaProperties;
@@ -42,6 +41,7 @@ import org.terracotta.angela.common.topology.PackageType;
 import org.terracotta.angela.common.topology.Topology;
 import org.terracotta.angela.common.topology.Version;
 import org.terracotta.angela.common.util.ExternalLoggers;
+import org.terracotta.angela.common.util.FileUtils;
 import org.terracotta.angela.common.util.HostPort;
 import org.terracotta.angela.common.util.OS;
 import org.terracotta.angela.common.util.ProcessUtil;
@@ -211,7 +211,7 @@ public class Distribution102Controller extends DistributionController {
       throw new RuntimeException(e);
     } finally {
       try {
-        FileUtils.deleteDirectory(tmpConfigDir);
+        FileUtils.deleteDirectory(tmpConfigDir.toPath());
       } catch (IOException ioe) {
         logger.error("Error deleting temporary cluster tool TC config files", ioe);
       }

--- a/common/src/main/java/org/terracotta/angela/common/util/FileUtils.java
+++ b/common/src/main/java/org/terracotta/angela/common/util/FileUtils.java
@@ -56,4 +56,8 @@ public class FileUtils {
       throw new UncheckedIOException(ioe);
     }
   }
+
+  public static void deleteDirectory(Path file) throws IOException {
+    org.terracotta.utilities.io.Files.deleteTree(file);
+  }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
             <artifactId>zt-exec</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>org.apache.commons</groupId>
+            <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
           </exclusion>
         </exclusions>


### PR DESCRIPTION
- Exclude `commons-io` correctly from `zt-process-killer` and use the right version of `commons-io`
  - Wrong flavor of `commons-io` was being excluded, which meant that we were using the `commons-io` from a transitive dependency, not the one we had intended to
- Move to terracotta-utilities `Files` for deletion of files
- Fixed broken `SecurityRootDirectoryTest`
  - Perform assertions correctly
  - Close streams