### PR TITLE
Update configs with proxy ports only if disruption is enabled

### DIFF
--- a/agent-lib/pom.xml
+++ b/agent-lib/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>angela-root</artifactId>
-    <version>3.0.51-SNAPSHOT</version>
+    <version>3.0.52-SNAPSHOT</version>
   </parent>
 
   <artifactId>angela-agent-lib</artifactId>

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>angela-root</artifactId>
-    <version>3.0.51-SNAPSHOT</version>
+    <version>3.0.52-SNAPSHOT</version>
   </parent>
 
   <artifactId>angela-agent</artifactId>

--- a/angela/pom.xml
+++ b/angela/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>angela-root</artifactId>
-    <version>3.0.51-SNAPSHOT</version>
+    <version>3.0.52-SNAPSHOT</version>
   </parent>
 
   <artifactId>angela</artifactId>

--- a/client-internal/pom.xml
+++ b/client-internal/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>angela-root</artifactId>
-    <version>3.0.51-SNAPSHOT</version>
+    <version>3.0.52-SNAPSHOT</version>
   </parent>
 
   <artifactId>angela-client-internal</artifactId>

--- a/client-internal/src/main/java/org/terracotta/angela/client/ClusterTool.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/ClusterTool.java
@@ -95,9 +95,8 @@ public class ClusterTool extends Tool {
     List<TcConfig> modifiedConfigs = new ArrayList<>();
     for (TcConfig tcConfig : tcConfigs) {
       TcConfig modifiedConfig = TcConfig.copy(tcConfig);
-      Map<ServerSymbolicName, Integer> proxyTsaPorts = updateToProxiedPorts();
-      if (!proxyTsaPorts.isEmpty()) {
-        modifiedConfig.updateServerTsaPort(proxyTsaPorts);
+      if (topology.isNetDisruptionEnabled()) {
+        modifiedConfig.updateServerTsaPort(updateToProxiedPorts());
       }
       modifiedConfig.writeTcConfigFile(tmpConfigDir);
       modifiedConfigs.add(modifiedConfig);

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>angela-root</artifactId>
-    <version>3.0.51-SNAPSHOT</version>
+    <version>3.0.52-SNAPSHOT</version>
   </parent>
 
   <artifactId>angela-common</artifactId>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>angela-root</artifactId>
-    <version>3.0.51-SNAPSHOT</version>
+    <version>3.0.52-SNAPSHOT</version>
   </parent>
 
   <artifactId>docs</artifactId>

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>angela-root</artifactId>
-    <version>3.0.51-SNAPSHOT</version>
+    <version>3.0.52-SNAPSHOT</version>
   </parent>
 
   <artifactId>integration-test</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
   <groupId>org.terracotta</groupId>
   <artifactId>angela-root</artifactId>
-  <version>3.0.51-SNAPSHOT</version>
+  <version>3.0.52-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>angela</name>
 


### PR DESCRIPTION
Found this problem while running angela-EE tests. After this, we can release a new angela version.