### PR TITLE
Provide .browse() API on cluster and config tools

### DIFF
--- a/agent-lib/src/main/java/org/terracotta/angela/agent/AgentController.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/agent/AgentController.java
@@ -32,6 +32,7 @@ import org.terracotta.angela.common.TerracottaManagementServerInstance;
 import org.terracotta.angela.common.TerracottaManagementServerState;
 import org.terracotta.angela.common.TerracottaServerInstance;
 import org.terracotta.angela.common.TerracottaServerState;
+import org.terracotta.angela.common.TerracottaToolInstance;
 import org.terracotta.angela.common.TerracottaVoter;
 import org.terracotta.angela.common.TerracottaVoterInstance;
 import org.terracotta.angela.common.TerracottaVoterState;
@@ -160,6 +161,24 @@ public class AgentController {
       throw new IllegalStateException("Server " + terracottaServer + " has not been installed");
     }
     return terracottaInstall.getInstallLocation(terracottaServer).getPath();
+  }
+
+  public String getConfigToolInstallPath(InstanceId instanceId) {
+    ToolInstall toolInstall = configToolInstalls.get(instanceId);
+    TerracottaToolInstance configToolInstance = toolInstall.getInstance();
+    if (configToolInstance == null) {
+      throw new IllegalStateException("Config tool has not been installed");
+    }
+    return toolInstall.getWorkingDir().getPath();
+  }
+
+  public String getClusterToolInstallPath(InstanceId instanceId) {
+    ToolInstall toolInstall = clusterToolInstalls.get(instanceId);
+    TerracottaToolInstance clusterToolInstance = toolInstall.getInstance();
+    if (clusterToolInstance == null) {
+      throw new IllegalStateException("Cluster tool has not been installed");
+    }
+    return toolInstall.getWorkingDir().getPath();
   }
 
   public String getTsaKitLocation(InstanceId instanceId, TerracottaServer terracottaServer) {

--- a/client-internal/src/main/java/org/terracotta/angela/client/ClusterTool.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/ClusterTool.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 import org.terracotta.angela.agent.Agent;
 import org.terracotta.angela.agent.kit.LocalKitManager;
 import org.terracotta.angela.client.config.ToolConfigurationContext;
+import org.terracotta.angela.client.filesystem.RemoteFolder;
 import org.terracotta.angela.client.util.IgniteClientHelper;
 import org.terracotta.angela.common.TerracottaCommandLineEnvironment;
 import org.terracotta.angela.common.ToolExecutionResult;
@@ -135,6 +136,12 @@ public class ClusterTool implements AutoCloseable {
   public void uninstall() {
     IgniteRunnable uninstaller = () -> Agent.controller.uninstallClusterTool(instanceId, configContext.getDistribution(), configContext.getHostName(), localKitManager.getKitInstallationName());
     IgniteClientHelper.executeRemotely(ignite, configContext.getHostName(), ignitePort, uninstaller);
+  }
+
+  public RemoteFolder browse(String root) {
+    String path = IgniteClientHelper.executeRemotely(ignite, configContext.getHostName(), ignitePort,
+        () -> Agent.controller.getClusterToolInstallPath(instanceId));
+    return new RemoteFolder(ignite, configContext.getHostName(), ignitePort, path, root);
   }
 
   @Override

--- a/client-internal/src/main/java/org/terracotta/angela/client/ConfigTool.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/ConfigTool.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 import org.terracotta.angela.agent.Agent;
 import org.terracotta.angela.agent.kit.LocalKitManager;
 import org.terracotta.angela.client.config.ToolConfigurationContext;
+import org.terracotta.angela.client.filesystem.RemoteFolder;
 import org.terracotta.angela.client.util.IgniteClientHelper;
 import org.terracotta.angela.common.TerracottaCommandLineEnvironment;
 import org.terracotta.angela.common.ToolException;
@@ -394,6 +395,12 @@ public class ConfigTool implements AutoCloseable {
         throw new RuntimeException("ConfigTool::executeCommand with command parameters failed with: " + executionResult);
       }
     }
+  }
+
+  public RemoteFolder browse(String root) {
+    String path = IgniteClientHelper.executeRemotely(ignite, configContext.getHostName(), ignitePort,
+        () -> Agent.controller.getConfigToolInstallPath(instanceId));
+    return new RemoteFolder(ignite, configContext.getHostName(), ignitePort, path, root);
   }
 
   @Override


### PR DESCRIPTION
Hopefully the last PR in this series. A full build is running at https://github.com/Terracotta-OSS/terracotta-platform/pull/883, where we'll get to know about any other failures apart from this.