### PR TITLE
Enabling to control the environment variables per process launched

### DIFF
--- a/agent-lib/src/main/java/org/terracotta/angela/agent/kit/ToolInstall.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/agent/kit/ToolInstall.java
@@ -20,13 +20,14 @@ import org.terracotta.angela.common.TerracottaToolInstance;
 import org.terracotta.angela.common.ToolExecutionResult;
 
 import java.io.File;
-import java.util.function.Function;
+import java.util.Map;
+import java.util.function.BiFunction;
 
 public class ToolInstall {
   private final TerracottaToolInstance toolInstance;
   private final File workingDir;
 
-  public ToolInstall(File workingDir, Function<String[], ToolExecutionResult> operation) {
+  public ToolInstall(File workingDir, BiFunction<Map<String, String>, String[], ToolExecutionResult> operation) {
     this.workingDir = workingDir;
     this.toolInstance = new TerracottaToolInstance(operation);
   }

--- a/client-internal/src/main/java/org/terracotta/angela/client/ClusterTool.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/ClusterTool.java
@@ -42,7 +42,9 @@ import org.terracotta.angela.common.topology.Topology;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import static org.terracotta.angela.common.AngelaProperties.KIT_COPY;
 import static org.terracotta.angela.common.AngelaProperties.KIT_INSTALLATION_DIR;
@@ -71,8 +73,12 @@ public class ClusterTool implements AutoCloseable {
     install();
   }
 
-  public ToolExecutionResult executeCommand(String... command) {
-    IgniteCallable<ToolExecutionResult> callable = () -> Agent.controller.clusterTool(instanceId, command);
+  public ToolExecutionResult executeCommand(String... arguments) {
+    return executeCommand(Collections.emptyMap(), arguments);
+  }
+
+  public ToolExecutionResult executeCommand(Map<String, String> env, String... command) {
+    IgniteCallable<ToolExecutionResult> callable = () -> Agent.controller.clusterTool(instanceId, env, command);
     return IgniteClientHelper.executeRemotely(ignite, configContext.getHostName(), ignitePort, callable);
   }
 

--- a/client-internal/src/main/java/org/terracotta/angela/client/ConfigTool.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/ConfigTool.java
@@ -39,6 +39,7 @@ import org.terracotta.angela.common.topology.Topology;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -70,7 +71,11 @@ public class ConfigTool implements AutoCloseable {
   }
 
   public ToolExecutionResult executeCommand(String... arguments) {
-    IgniteCallable<ToolExecutionResult> callable = () -> Agent.controller.configTool(instanceId, arguments);
+    return executeCommand(Collections.emptyMap(), arguments);
+  }
+
+  public ToolExecutionResult executeCommand(Map<String, String> env, String... arguments) {
+    IgniteCallable<ToolExecutionResult> callable = () -> Agent.controller.configTool(instanceId, env, arguments);
     return IgniteClientHelper.executeRemotely(ignite, configContext.getHostName(), ignitePort, callable);
   }
 

--- a/client-internal/src/main/java/org/terracotta/angela/client/Tms.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/Tms.java
@@ -35,6 +35,9 @@ import org.terracotta.angela.common.tms.security.config.TmsServerSecurityConfig;
 import org.terracotta.angela.common.topology.InstanceId;
 import org.terracotta.angela.common.util.HostPort;
 
+import java.util.Collections;
+import java.util.Map;
+
 import static java.util.Collections.singleton;
 import static org.terracotta.angela.common.AngelaProperties.KIT_INSTALLATION_DIR;
 import static org.terracotta.angela.common.AngelaProperties.KIT_INSTALLATION_PATH;
@@ -106,9 +109,13 @@ public class Tms implements AutoCloseable {
   }
 
   public Tms start() {
+    return start(Collections.emptyMap());
+  }
+
+  public Tms start(Map<String, String> envOverrides) {
     String tmsHostname = tmsConfigurationContext.getHostname();
     logger.info("Starting TMS on {}", tmsHostname);
-    IgniteClientHelper.executeRemotely(ignite, tmsHostname, ignitePort, () -> Agent.controller.startTms(instanceId));
+    IgniteClientHelper.executeRemotely(ignite, tmsHostname, ignitePort, () -> Agent.controller.startTms(instanceId, envOverrides));
     return this;
   }
 

--- a/client-internal/src/main/java/org/terracotta/angela/client/Tsa.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/Tsa.java
@@ -222,6 +222,10 @@ public class Tsa implements AutoCloseable {
   }
 
   public Tsa create(TerracottaServer terracottaServer, String... startUpArgs) {
+    return create(terracottaServer, Collections.emptyMap(), startUpArgs);
+  }
+
+  public Tsa create(TerracottaServer terracottaServer, Map<String, String> envOverrides, String... startUpArgs) {
     TerracottaServerState terracottaServerState = getState(terracottaServer);
     switch (terracottaServerState) {
       case STARTING:
@@ -234,7 +238,7 @@ public class Tsa implements AutoCloseable {
         IgniteRunnable tsaCreator = () -> {
           String whatFor = SERVER_START_PREFIX + terracottaServer.getServerSymbolicName().getSymbolicName();
           TerracottaCommandLineEnvironment cliEnv = tsaConfigurationContext.getTerracottaCommandLineEnvironment(whatFor);
-          Agent.controller.createTsa(instanceId, terracottaServer, cliEnv, Arrays.asList(startUpArgs));
+          Agent.controller.createTsa(instanceId, terracottaServer, cliEnv, envOverrides, Arrays.asList(startUpArgs));
         };
         IgniteClientHelper.executeRemotely(ignite, terracottaServer.getHostname(), ignitePort, tsaCreator);
         return this;
@@ -253,9 +257,12 @@ public class Tsa implements AutoCloseable {
     return disruptionController;
   }
 
-
   public Tsa start(TerracottaServer terracottaServer, String... startUpArgs) {
-    create(terracottaServer, startUpArgs);
+    return start(terracottaServer, Collections.emptyMap(), startUpArgs);
+  }
+
+  public Tsa start(TerracottaServer terracottaServer, Map<String, String> envOverrides, String... startUpArgs) {
+    create(terracottaServer, envOverrides, startUpArgs);
     IgniteRunnable runnable = () -> Agent.controller.waitForTsaInState(instanceId, terracottaServer,
         of(STARTED_AS_ACTIVE, STARTED_AS_PASSIVE, STARTED_IN_DIAGNOSTIC_MODE, START_SUSPENDED));
     IgniteClientHelper.executeRemotely(ignite, terracottaServer.getHostname(), ignitePort, runnable);

--- a/client-internal/src/main/java/org/terracotta/angela/client/Voter.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/Voter.java
@@ -35,7 +35,9 @@ import org.terracotta.angela.common.tcconfig.SecurityRootDirectory;
 import org.terracotta.angela.common.topology.InstanceId;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import static org.terracotta.angela.common.AngelaProperties.KIT_COPY;
@@ -84,7 +86,11 @@ public class Voter implements AutoCloseable {
   }
 
   public Voter start(TerracottaVoter terracottaVoter) {
-    IgniteClientHelper.executeRemotely(ignite, terracottaVoter.getHostName(), ignitePort, () -> Agent.controller.startVoter(instanceId, terracottaVoter));
+    return start(terracottaVoter, Collections.emptyMap());
+  }
+
+  public Voter start(TerracottaVoter terracottaVoter, Map<String, String> envOverrides) {
+    IgniteClientHelper.executeRemotely(ignite, terracottaVoter.getHostName(), ignitePort, () -> Agent.controller.startVoter(instanceId, terracottaVoter, envOverrides));
     return this;
   }
 

--- a/common/src/main/java/org/terracotta/angela/common/TerracottaManagementServerInstance.java
+++ b/common/src/main/java/org/terracotta/angela/common/TerracottaManagementServerInstance.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -42,8 +43,8 @@ public class TerracottaManagementServerInstance {
     this.tcEnv = tcEnv;
   }
 
-  public void start() {
-    this.terracottaManagementServerInstanceProcess = this.distributionController.startTms(kitDir, workingDir, tcEnv);
+  public void start(Map<String, String> envOverrides) {
+    this.terracottaManagementServerInstanceProcess = this.distributionController.startTms(kitDir, workingDir, tcEnv, envOverrides);
   }
 
   public void stop() {

--- a/common/src/main/java/org/terracotta/angela/common/TerracottaServerInstance.java
+++ b/common/src/main/java/org/terracotta/angela/common/TerracottaServerInstance.java
@@ -92,8 +92,8 @@ public class TerracottaServerInstance implements Closeable {
     return distribution;
   }
 
-  public void create(TerracottaCommandLineEnvironment env, List<String> startUpArgs) {
-    this.terracottaServerInstanceProcess = this.distributionController.createTsa(terracottaServer, kitDir, workingDir, topology, proxiedPorts, env, startUpArgs);
+  public void create(TerracottaCommandLineEnvironment env, Map<String, String> envOverrides, List<String> startUpArgs) {
+    this.terracottaServerInstanceProcess = this.distributionController.createTsa(terracottaServer, kitDir, workingDir, topology, proxiedPorts, env, envOverrides, startUpArgs);
   }
 
   public void disrupt(Collection<TerracottaServer> targets) {

--- a/common/src/main/java/org/terracotta/angela/common/TerracottaToolInstance.java
+++ b/common/src/main/java/org/terracotta/angela/common/TerracottaToolInstance.java
@@ -16,16 +16,17 @@
  */
 package org.terracotta.angela.common;
 
-import java.util.function.Function;
+import java.util.Map;
+import java.util.function.BiFunction;
 
 public class TerracottaToolInstance {
-  private final Function<String[], ToolExecutionResult> operation;
+  private final BiFunction<Map<String, String>, String[], ToolExecutionResult> operation;
 
-  public TerracottaToolInstance(Function<String[], ToolExecutionResult> operation) {
+  public TerracottaToolInstance(BiFunction<Map<String, String>, String[], ToolExecutionResult> operation) {
     this.operation = operation;
   }
 
-  public ToolExecutionResult execute(String... command) {
-    return operation.apply(command);
+  public ToolExecutionResult execute(Map<String, String> env, String... command) {
+    return operation.apply(env, command);
   }
 }

--- a/common/src/main/java/org/terracotta/angela/common/TerracottaVoterInstance.java
+++ b/common/src/main/java/org/terracotta/angela/common/TerracottaVoterInstance.java
@@ -21,9 +21,10 @@ import org.terracotta.angela.common.distribution.DistributionController;
 import org.terracotta.angela.common.tcconfig.SecurityRootDirectory;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -47,8 +48,8 @@ public class TerracottaVoterInstance {
     this.tcEnv = tcEnv;
   }
 
-  public void start() {
-    terracottaVoterInstanceProcess = distributionController.startVoter(terracottaVoter, kitDir, workingDir, securityRootDirectory, tcEnv);
+  public void start(Map<String, String> envOverrides) {
+    terracottaVoterInstanceProcess = distributionController.startVoter(terracottaVoter, kitDir, workingDir, securityRootDirectory, tcEnv, envOverrides);
   }
 
   public void stop() {

--- a/common/src/main/java/org/terracotta/angela/common/distribution/Distribution102Controller.java
+++ b/common/src/main/java/org/terracotta/angela/common/distribution/Distribution102Controller.java
@@ -79,8 +79,8 @@ public class Distribution102Controller extends DistributionController {
   @Override
   public TerracottaServerInstanceProcess createTsa(TerracottaServer terracottaServer, File kitDir, File workingDir,
                                                    Topology topology, Map<ServerSymbolicName, Integer> proxiedPorts,
-                                                   TerracottaCommandLineEnvironment tcEnv, List<String> startUpArgs) {
-    Map<String, String> env = buildEnv(tcEnv);
+                                                   TerracottaCommandLineEnvironment tcEnv, Map<String, String> envOverrides, List<String> startUpArgs) {
+    Map<String, String> env = tcEnv.buildEnv(javaLocationResolver, envOverrides);
     AtomicReference<TerracottaServerState> stateRef = new AtomicReference<>(TerracottaServerState.STOPPED);
     AtomicInteger javaPid = new AtomicInteger(-1);
 
@@ -129,11 +129,11 @@ public class Distribution102Controller extends DistributionController {
 
   @Override
   public ToolExecutionResult invokeClusterTool(File kitDir, File workingDir, SecurityRootDirectory securityDir,
-                                               TerracottaCommandLineEnvironment env, String... arguments) {
+                                               TerracottaCommandLineEnvironment env, Map<String, String> envOverrides, String... arguments) {
     try {
       ProcessResult processResult = new ProcessExecutor(createClusterToolCommand(kitDir, workingDir, securityDir, arguments))
           .directory(workingDir)
-          .environment(buildEnv(env))
+          .environment(env.buildEnv(javaLocationResolver, envOverrides))
           .readOutput(true)
           .redirectOutputAlsoTo(Slf4jStream.of(ExternalLoggers.clusterToolLogger).asInfo())
           .redirectErrorStream(true)
@@ -147,13 +147,13 @@ public class Distribution102Controller extends DistributionController {
 
   @Override
   public ToolExecutionResult invokeConfigTool(File kitDir, File workingDir, SecurityRootDirectory securityDir,
-                                                    TerracottaCommandLineEnvironment env, String... arguments) {
+                                                    TerracottaCommandLineEnvironment env, Map<String, String> envOverrides, String... arguments) {
     throw new UnsupportedOperationException("Running config tool is not supported in this distribution version");
   }
 
   @Override
-  public TerracottaManagementServerInstanceProcess startTms(File kitDir, File workingDir, TerracottaCommandLineEnvironment tcEnv) {
-    Map<String, String> env = buildEnv(tcEnv);
+  public TerracottaManagementServerInstanceProcess startTms(File kitDir, File workingDir, TerracottaCommandLineEnvironment tcEnv, Map<String, String> envOverrides) {
+    Map<String, String> env = tcEnv.buildEnv(javaLocationResolver, envOverrides);
 
     AtomicReference<TerracottaManagementServerState> stateRef = new AtomicReference<>(TerracottaManagementServerState.STOPPED);
     AtomicInteger javaPid = new AtomicInteger(-1);
@@ -206,7 +206,7 @@ public class Distribution102Controller extends DistributionController {
 
   @Override
   public TerracottaVoterInstanceProcess startVoter(TerracottaVoter terracottaVoter, File kitDir, File workingDir,
-                                                   SecurityRootDirectory securityDir, TerracottaCommandLineEnvironment tcEnv) {
+                                                   SecurityRootDirectory securityDir, TerracottaCommandLineEnvironment tcEnv, Map<String, String> envOverrides) {
     throw new UnsupportedOperationException("Running voter is not supported in this distribution version");
   }
 

--- a/common/src/main/java/org/terracotta/angela/common/distribution/Distribution107Controller.java
+++ b/common/src/main/java/org/terracotta/angela/common/distribution/Distribution107Controller.java
@@ -78,8 +78,8 @@ public class Distribution107Controller extends DistributionController {
   @Override
   public TerracottaServerInstanceProcess createTsa(TerracottaServer terracottaServer, File kitDir, File workingDir,
                                                    Topology topology, Map<ServerSymbolicName, Integer> proxiedPorts,
-                                                   TerracottaCommandLineEnvironment tcEnv, List<String> startUpArgs) {
-    Map<String, String> env = buildEnv(tcEnv);
+                                                   TerracottaCommandLineEnvironment tcEnv, Map<String, String> envOverrides, List<String> startUpArgs) {
+    Map<String, String> env = tcEnv.buildEnv(javaLocationResolver, envOverrides);
     AtomicReference<TerracottaServerState> stateRef = new AtomicReference<>(TerracottaServerState.STOPPED);
     AtomicInteger javaPid = new AtomicInteger(-1);
 
@@ -134,8 +134,8 @@ public class Distribution107Controller extends DistributionController {
   }
 
   @Override
-  public TerracottaManagementServerInstanceProcess startTms(File kitDir, File workingDir, TerracottaCommandLineEnvironment tcEnv) {
-    Map<String, String> env = buildEnv(tcEnv);
+  public TerracottaManagementServerInstanceProcess startTms(File kitDir, File workingDir, TerracottaCommandLineEnvironment tcEnv, Map<String, String> envOverrides) {
+    Map<String, String> env = tcEnv.buildEnv(javaLocationResolver, envOverrides);
 
     AtomicReference<TerracottaManagementServerState> stateRef = new AtomicReference<>(TerracottaManagementServerState.STOPPED);
     AtomicInteger javaPid = new AtomicInteger(-1);
@@ -188,8 +188,8 @@ public class Distribution107Controller extends DistributionController {
 
   @Override
   public TerracottaVoterInstanceProcess startVoter(TerracottaVoter terracottaVoter, File kitDir, File workingDir,
-                                                   SecurityRootDirectory securityDir, TerracottaCommandLineEnvironment tcEnv) {
-    Map<String, String> env = buildEnv(tcEnv);
+                                                   SecurityRootDirectory securityDir, TerracottaCommandLineEnvironment tcEnv, Map<String, String> envOverrides) {
+    Map<String, String> env = tcEnv.buildEnv(javaLocationResolver, envOverrides);
 
     AtomicReference<TerracottaVoterState> stateRef = new AtomicReference<>(TerracottaVoterState.STOPPED);
     AtomicInteger javaPid = new AtomicInteger(-1);
@@ -247,11 +247,11 @@ public class Distribution107Controller extends DistributionController {
 
   @Override
   public ToolExecutionResult invokeClusterTool(File kitDir, File workingDir, SecurityRootDirectory securityDir,
-                                                      TerracottaCommandLineEnvironment env, String... arguments) {
+                                                      TerracottaCommandLineEnvironment env, Map<String, String> envOverrides, String... arguments) {
     try {
       ProcessResult processResult = new ProcessExecutor(createClusterToolCommand(kitDir, workingDir, securityDir, arguments))
           .directory(workingDir)
-          .environment(buildEnv(env))
+          .environment(env.buildEnv(javaLocationResolver, envOverrides))
           .readOutput(true)
           .redirectOutputAlsoTo(Slf4jStream.of(ExternalLoggers.clusterToolLogger).asInfo())
           .redirectErrorStream(true)
@@ -265,11 +265,11 @@ public class Distribution107Controller extends DistributionController {
 
   @Override
   public ToolExecutionResult invokeConfigTool(File kitDir, File workingDir, SecurityRootDirectory securityDir,
-                                              TerracottaCommandLineEnvironment env, String... command) {
+                                              TerracottaCommandLineEnvironment env, Map<String, String> envOverrides, String... command) {
     try {
       ProcessResult processResult = new ProcessExecutor(createConfigToolCommand(kitDir, workingDir, securityDir, command))
           .directory(workingDir)
-          .environment(buildEnv(env))
+          .environment(env.buildEnv(javaLocationResolver, envOverrides))
           .readOutput(true)
           .redirectOutputAlsoTo(Slf4jStream.of(ExternalLoggers.configToolLogger).asInfo())
           .redirectErrorStream(true)

--- a/common/src/main/java/org/terracotta/angela/common/distribution/Distribution43Controller.java
+++ b/common/src/main/java/org/terracotta/angela/common/distribution/Distribution43Controller.java
@@ -85,7 +85,7 @@ public class Distribution43Controller extends DistributionController {
   @Override
   public TerracottaServerInstanceProcess createTsa(TerracottaServer terracottaServer, File kitDir, File workingDir,
                                                    Topology topology, Map<ServerSymbolicName, Integer> proxiedPorts,
-                                                   TerracottaCommandLineEnvironment tcEnv, List<String> startUpArgs) {
+                                                   TerracottaCommandLineEnvironment tcEnv, Map<String, String> envOverrides, List<String> startUpArgs) {
     AtomicReference<TerracottaServerState> stateRef = new AtomicReference<>(STOPPED);
     AtomicReference<TerracottaServerState> tempStateRef = new AtomicReference<>(STOPPED);
 
@@ -113,7 +113,7 @@ public class Distribution43Controller extends DistributionController {
         serverLogOutputStream.andTriggerOn(compile("^.*(WARN|ERROR).*$"), mr -> ExternalLoggers.tsaLogger.info("[{}] {}", terracottaServer.getServerSymbolicName().getSymbolicName(), mr.group()));
 
     // add an identifiable ID to the JVM's system properties
-    Map<String, String> env = buildEnv(tcEnv);
+    Map<String, String> env = tcEnv.buildEnv(javaLocationResolver, envOverrides);
     env.compute("JAVA_OPTS", (key, value) -> {
       String prop = " -Dangela.processIdentifier=" + terracottaServer.getId();
       return value == null ? prop : value + prop;
@@ -203,13 +203,13 @@ public class Distribution43Controller extends DistributionController {
 
   @Override
   public ToolExecutionResult invokeClusterTool(File kitDir, File workingDir, SecurityRootDirectory securityDir,
-                                               TerracottaCommandLineEnvironment env, String... arguments) {
+                                               TerracottaCommandLineEnvironment env, Map<String, String> envOverrides, String... arguments) {
     throw new UnsupportedOperationException("Running cluster tool is not supported in this distribution version");
   }
 
   @Override
   public ToolExecutionResult invokeConfigTool(File kitDir, File workingDir, SecurityRootDirectory securityDir,
-                                              TerracottaCommandLineEnvironment env, String... arguments) {
+                                              TerracottaCommandLineEnvironment env, Map<String, String> envOverrides, String... arguments) {
     throw new UnsupportedOperationException("Running config tool is not supported in this distribution version");
   }
 
@@ -275,7 +275,7 @@ public class Distribution43Controller extends DistributionController {
   }
 
   @Override
-  public TerracottaManagementServerInstanceProcess startTms(File kitDir, File workingDir, TerracottaCommandLineEnvironment tcEnv) {
+  public TerracottaManagementServerInstanceProcess startTms(File kitDir, File workingDir, TerracottaCommandLineEnvironment tcEnv, Map<String, String> envOverrides) {
     throw new UnsupportedOperationException("NOT YET IMPLEMENTED");
   }
 
@@ -286,7 +286,7 @@ public class Distribution43Controller extends DistributionController {
 
   @Override
   public TerracottaVoterInstanceProcess startVoter(TerracottaVoter terracottaVoter, File kitDir, File workingDir,
-                                                   SecurityRootDirectory securityDir, TerracottaCommandLineEnvironment tcEnv) {
+                                                   SecurityRootDirectory securityDir, TerracottaCommandLineEnvironment tcEnv, Map<String, String> envOverrides) {
     throw new UnsupportedOperationException("Running voter is not supported in this distribution version");
   }
 

--- a/common/src/main/java/org/terracotta/angela/common/distribution/DistributionController.java
+++ b/common/src/main/java/org/terracotta/angela/common/distribution/DistributionController.java
@@ -43,10 +43,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * @author Aurelien Broszniowski
@@ -62,21 +60,6 @@ public abstract class DistributionController {
 
   DistributionController(Distribution distribution) {
     this.distribution = distribution;
-  }
-
-  protected Map<String, String> buildEnv(TerracottaCommandLineEnvironment tcEnv) {
-    Map<String, String> env = new HashMap<>();
-    String javaHome = tcEnv.getJavaHome().orElseGet(()->javaLocationResolver.resolveJavaLocation(tcEnv).getHome());
-    env.put("JAVA_HOME", javaHome);
-    LOGGER.info(" JAVA_HOME = {}", javaHome);
-
-    Set<String> javaOpts = tcEnv.getJavaOpts();
-    if (!javaOpts.isEmpty()) {
-      String joinedJavaOpts = String.join(" ", javaOpts);
-      env.put("JAVA_OPTS", joinedJavaOpts);
-      LOGGER.info(" JAVA_OPTS = {}", joinedJavaOpts);
-    }
-    return env;
   }
 
   public ToolExecutionResult invokeJcmd(TerracottaServerInstance.TerracottaServerInstanceProcess terracottaServerInstanceProcess, TerracottaCommandLineEnvironment tcEnv, String... arguments) {
@@ -107,9 +90,9 @@ public abstract class DistributionController {
     }
   }
 
-  public abstract TerracottaServerInstance.TerracottaServerInstanceProcess createTsa(TerracottaServer terracottaServer, File kitDir, File workingDir, Topology topology, Map<ServerSymbolicName, Integer> proxiedPorts, TerracottaCommandLineEnvironment tcEnv, List<String> startUpArgs);
+  public abstract TerracottaServerInstance.TerracottaServerInstanceProcess createTsa(TerracottaServer terracottaServer, File kitDir, File workingDir, Topology topology, Map<ServerSymbolicName, Integer> proxiedPorts, TerracottaCommandLineEnvironment tcEnv, Map<String, String> envOverrides, List<String> startUpArgs);
 
-  public abstract TerracottaManagementServerInstance.TerracottaManagementServerInstanceProcess startTms(File kitDir, File workingDir, TerracottaCommandLineEnvironment env);
+  public abstract TerracottaManagementServerInstance.TerracottaManagementServerInstanceProcess startTms(File kitDir, File workingDir, TerracottaCommandLineEnvironment env, Map<String, String> envOverrides);
 
   public abstract void stopTms(File installLocation, TerracottaManagementServerInstance.TerracottaManagementServerInstanceProcess terracottaServerInstanceProcess, TerracottaCommandLineEnvironment tcEnv);
 
@@ -138,15 +121,15 @@ public abstract class DistributionController {
   }
 
   public abstract TerracottaVoterInstanceProcess startVoter(TerracottaVoter terracottaVoter, File kitDir, File workingDir,
-                                                            SecurityRootDirectory securityDir, TerracottaCommandLineEnvironment tcEnv);
+                                                            SecurityRootDirectory securityDir, TerracottaCommandLineEnvironment tcEnv, Map<String, String> envOverrides);
 
   public abstract void stopVoter(TerracottaVoterInstanceProcess terracottaVoterInstanceProcess);
 
   public abstract ToolExecutionResult invokeClusterTool(File kitDir, File workingDir, SecurityRootDirectory securityDir,
-                                                        TerracottaCommandLineEnvironment env, String... arguments);
+                                                        TerracottaCommandLineEnvironment env, Map<String, String> envOverrides, String... arguments);
 
   public abstract ToolExecutionResult invokeConfigTool(File kitDir, File workingDir, SecurityRootDirectory securityDir,
-                                                       TerracottaCommandLineEnvironment env, String... arguments);
+                                                       TerracottaCommandLineEnvironment env, Map<String, String> envOverrides, String... arguments);
 
   public abstract URI tsaUri(Collection<TerracottaServer> servers, Map<ServerSymbolicName, Integer> proxyTsaPorts);
 

--- a/common/src/main/java/org/terracotta/angela/common/util/TriggeringOutputStream.java
+++ b/common/src/main/java/org/terracotta/angela/common/util/TriggeringOutputStream.java
@@ -42,7 +42,8 @@ public class TriggeringOutputStream extends LogOutputStream {
             consumer.accept(line);
           } finally {
             Matcher matcher = pattern.matcher(line);
-            if (matcher.matches()) {
+            if (matcher
+                .matches()) {
               action.accept(matcher.toMatchResult());
             }
           }


### PR DESCRIPTION
This can be used for example to specify a specific JAVA_OPTS env variable at one point in a system tests to specifically debug only one process but not all.

Example:

```java

  @Test
  public void setUnsetBackupDir() {
    Map<String, String> env = singletonMap("JAVA_OPTS", "-Xms8m -Xmx128m -Djdk.security.allowNonCaAnchor=true -agentlib:jdwp=transport=dt_socket,server=n,address=localhost:5005,suspend=y");

    // set backup dir: we should not have any warning
    assertThat(
        invokeConfigTool(env, "set", "-s", "localhost:" + getNodePort(), "-c", "backup-dir=foo"),
        not(containsOutput("IMPORTANT: A restart of nodes: node-1-1 is required")));

    // ensure we have the value set at runtime
    assertThat(
        invokeConfigTool("get", "-r", "-s", "localhost:" + getNodePort(), "-c", "backup-dir"),
        containsOutput("stripe.1.node.1.backup-dir=foo"));
```