### PR TITLE
Correcting the contract of angela.kitInstallationDir

### DIFF
--- a/agent-lib/src/main/java/org/terracotta/angela/agent/AgentController.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/agent/AgentController.java
@@ -71,6 +71,7 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
@@ -129,15 +130,13 @@ public class AgentController {
         workingDir = kitManager.getWorkingDir().toFile();
         terracottaInstall = tsaInstalls.computeIfAbsent(instanceId, (iid) -> new TerracottaInstall(workingDir, portAllocator));
       } else {
+        // DO NOT ALTER THE KIT CONTENT IF kitInstallationPath IS USED
         kitLocation = new File(kitInstallationPath);
-        if (license !=null) {
-          license.writeToFile(kitLocation);
-        }
         Path workingPath = Agent.WORK_DIR.resolve(instanceId.toString());
         try {
           Files.createDirectories(workingPath);
         } catch (IOException e) {
-          logger.debug("Can not create {}", workingPath,e);
+          logger.debug("Can not create {}", workingPath, e);
         }
         workingDir = workingPath.toFile();
 
@@ -201,47 +200,47 @@ public class AgentController {
 
   public boolean installTms(InstanceId instanceId, String tmsHostname, Distribution distribution, License license,
                             TmsServerSecurityConfig tmsServerSecurityConfig, String kitInstallationName,
-                            TerracottaCommandLineEnvironment tcEnv, Collection<String> hostNames) {
+                            TerracottaCommandLineEnvironment tcEnv, String hostName, String kitInstallationPath) {
     TmsInstall tmsInstall = tmsInstalls.get(instanceId);
     if (tmsInstall != null) {
       logger.debug("Kit for " + tmsHostname + " already installed");
       tmsInstall.addTerracottaManagementServer();
       return true;
+
     } else {
-      logger.debug("Attempting to install kit from cached install for " + tmsHostname);
-      RemoteKitManager kitManager = new RemoteKitManager(instanceId, distribution, kitInstallationName);
 
-      if (kitManager.isKitAvailable()) {
-        File kitDir = kitManager.installKit(license, hostNames);
-        File workingDir = kitManager.getWorkingDir().toFile();
+      Optional<Dirs> dirs = Dirs.discover(instanceId, hostName, distribution, license, kitInstallationName, kitInstallationPath);
+      if (!dirs.isPresent()) {
+        return false;
+      }
 
+      // DO NOT ALTER THE KIT CONTENT IF kitInstallationPath IS USED
+      if(kitInstallationPath == null) {
+        File kitDir = dirs.get().kitManager.installKit(license, Collections.singleton(hostName));
         File tmcProperties = new File(kitDir, "/tools/management/conf/tmc.properties");
         if (tmsServerSecurityConfig != null) {
           enableTmsSecurity(tmcProperties, tmsServerSecurityConfig);
         }
-        tmsInstalls.put(instanceId, new TmsInstall(distribution, kitDir, workingDir, tcEnv));
-        return true;
-      } else {
-        return false;
       }
+
+      tmsInstalls.put(instanceId, new TmsInstall(distribution, dirs.get().kitDir, dirs.get().workingDir, tcEnv));
+      return true;
     }
   }
 
   public boolean installVoter(InstanceId instanceId, TerracottaVoter terracottaVoter, Distribution distribution,
                               License license, String kitInstallationName, SecurityRootDirectory securityRootDirectory,
-                              TerracottaCommandLineEnvironment tcEnv) {
+                              TerracottaCommandLineEnvironment tcEnv, String kitInstallationPath) {
     VoterInstall voterInstall = voterInstalls.get(instanceId);
 
     if (voterInstall == null) {
-      RemoteKitManager kitManager = new RemoteKitManager(instanceId, distribution, kitInstallationName);
-      if (!kitManager.isKitAvailable()) {
+
+      Optional<Dirs> dirs = Dirs.discover(instanceId, terracottaVoter.getHostName(), distribution, license, kitInstallationName, kitInstallationPath);
+      if (!dirs.isPresent()) {
         return false;
       }
 
-      logger.info("Installing kit for {} from {}", terracottaVoter, distribution);
-      File kitDir = kitManager.installKit(license, Collections.singletonList(terracottaVoter.getHostName()));
-      File workingDir = kitManager.getWorkingDir().toFile();
-      voterInstall = voterInstalls.computeIfAbsent(instanceId, (id) -> new VoterInstall(distribution, kitDir, workingDir, securityRootDirectory, tcEnv));
+      voterInstall = voterInstalls.computeIfAbsent(instanceId, (id) -> new VoterInstall(distribution, dirs.get().kitDir, dirs.get().workingDir, securityRootDirectory, tcEnv));
     }
 
     voterInstall.addVoter(terracottaVoter);
@@ -251,23 +250,21 @@ public class AgentController {
 
   public boolean installClusterTool(InstanceId instanceId, String hostName, Distribution distribution,
                                     License license, String kitInstallationName, SecurityRootDirectory securityRootDirectory,
-                                    TerracottaCommandLineEnvironment tcEnv) {
+                                    TerracottaCommandLineEnvironment tcEnv, String kitInstallationPath) {
     ToolInstall clusterToolInstall = clusterToolInstalls.get(instanceId);
     if (clusterToolInstall == null) {
-      RemoteKitManager kitManager = new RemoteKitManager(instanceId, distribution, kitInstallationName);
-      if (!kitManager.isKitAvailable()) {
+
+      Optional<Dirs> dirs = Dirs.discover(instanceId, hostName, distribution, license, kitInstallationName, kitInstallationPath);
+      if (!dirs.isPresent()) {
         return false;
       }
 
-      logger.info("Installing kit on host {} from {}", hostName, distribution);
-      File kitDir = kitManager.installKit(license, Collections.singletonList(hostName));
-      File workingDir = kitManager.getWorkingDir().toFile();
       clusterToolInstalls.computeIfAbsent(instanceId, id -> {
         BiFunction<Map<String, String>, String[], ToolExecutionResult> operation = (env, command) -> {
           DistributionController distributionController = distribution.createDistributionController();
-          return distributionController.invokeClusterTool(kitDir, workingDir, securityRootDirectory, tcEnv, env, command);
+          return distributionController.invokeClusterTool(dirs.get().kitDir, dirs.get().workingDir, securityRootDirectory, tcEnv, env, command);
         };
-        return new ToolInstall(workingDir, operation);
+        return new ToolInstall(dirs.get().workingDir, operation);
       });
     }
     return true;
@@ -275,24 +272,22 @@ public class AgentController {
 
   public boolean installConfigTool(InstanceId instanceId, String hostName, Distribution distribution,
                                    License license, String kitInstallationName, SecurityRootDirectory securityRootDirectory,
-                                   TerracottaCommandLineEnvironment tcEnv) {
+                                   TerracottaCommandLineEnvironment tcEnv, String kitInstallationPath) {
     ToolInstall configToolInstall = configToolInstalls.get(instanceId);
 
     if (configToolInstall == null) {
-      RemoteKitManager kitManager = new RemoteKitManager(instanceId, distribution, kitInstallationName);
-      if (!kitManager.isKitAvailable()) {
+
+      Optional<Dirs> dirs = Dirs.discover(instanceId, hostName, distribution, license, kitInstallationName, kitInstallationPath);
+      if (!dirs.isPresent()) {
         return false;
       }
 
-      logger.info("Installing kit for host {} from {}", hostName, distribution);
-      File kitDir = kitManager.installKit(license, Collections.singletonList(hostName));
-      File workingDir = kitManager.getWorkingDir().toFile();
       configToolInstalls.computeIfAbsent(instanceId, id -> {
         BiFunction<Map<String, String>, String[], ToolExecutionResult> operation = (env, command) -> {
           DistributionController distributionController = distribution.createDistributionController();
-          return distributionController.invokeConfigTool(kitDir, workingDir, securityRootDirectory, tcEnv, env, command);
+          return distributionController.invokeConfigTool(dirs.get().kitDir, dirs.get().workingDir, securityRootDirectory, tcEnv, env, command);
         };
-        return new ToolInstall(workingDir, operation);
+        return new ToolInstall(dirs.get().workingDir, operation);
       });
     }
     return true;
@@ -390,12 +385,15 @@ public class AgentController {
   }
 
   public void uninstallTms(InstanceId instanceId, Distribution distribution, TmsServerSecurityConfig tmsServerSecurityConfig,
-                           String kitInstallationName, String tmsHostname) {
+                           String kitInstallationName, String tmsHostname, String kitInstallationPath) {
     TmsInstall tmsInstall = tmsInstalls.get(instanceId);
     if (tmsInstall != null) {
-      File tmcProperties = new File(tmsInstall.getKitLocation(), "/tools/management/conf/tmc.properties");
-      if (tmsServerSecurityConfig != null) {
-        disableTmsSecurity(tmcProperties, tmsServerSecurityConfig);
+      // DO NOT ALTER THE KIT CONTENT IF kitInstallationPath IS USED
+      if(kitInstallationPath == null) {
+        File tmcProperties = new File(tmsInstall.getKitLocation(), "/tools/management/conf/tmc.properties");
+        if (tmsServerSecurityConfig != null) {
+          disableTmsSecurity(tmcProperties, tmsServerSecurityConfig);
+        }
       }
       tmsInstall.removeServer();
       tmsInstalls.remove(instanceId);
@@ -626,7 +624,7 @@ public class AgentController {
           break;
         }
 
-        FileMetadata fileMetadata = (FileMetadata)read;
+        FileMetadata fileMetadata = (FileMetadata) read;
         logger.debug("downloading " + fileMetadata);
         if (!fileMetadata.isDirectory()) {
           long readFileLength = 0L;
@@ -638,7 +636,7 @@ public class AgentController {
                 throw new RuntimeException("Error downloading file : " + fileMetadata);
               }
 
-              byte[] buffer = (byte[])queue.take();
+              byte[] buffer = (byte[]) queue.take();
               fos.write(buffer);
               readFileLength += buffer.length;
             }
@@ -724,5 +722,48 @@ public class AgentController {
 
   public Map<String, ?> getNodeAttributes() {
     return ignite.configuration().getUserAttributes();
+  }
+
+  private static class Dirs {
+    final File kitDir;
+    final File workingDir;
+    final RemoteKitManager kitManager;
+
+    public Dirs(File kitDir, File workingDir, RemoteKitManager kitManager) {
+      this.kitDir = kitDir;
+      this.workingDir = workingDir;
+      this.kitManager = kitManager;
+    }
+
+    static Optional<Dirs> discover(InstanceId instanceId, String hostName, Distribution distribution, License license, String kitInstallationName, String kitInstallationPath) {
+      if (kitInstallationPath == null) {
+        RemoteKitManager kitManager = new RemoteKitManager(instanceId, distribution, kitInstallationName);
+        if (!kitManager.isKitAvailable()) {
+          return Optional.empty();
+        }
+
+        logger.info("Installing kit on host {} from {}", hostName, distribution);
+        return Optional.of(new Dirs(
+            kitManager.installKit(license, Collections.singletonList(hostName)),
+            kitManager.getWorkingDir().toFile(),
+            kitManager
+        ));
+
+      } else {
+        // DO NOT ALTER THE KIT CONTENT IF kitInstallationPath IS USED
+        File kitDir = new File(kitInstallationPath);
+        Path workingPath = Agent.WORK_DIR.resolve(instanceId.toString());
+        try {
+          Files.createDirectories(workingPath);
+        } catch (IOException e) {
+          logger.debug("Can not create {}", workingPath, e);
+        }
+        return Optional.of(new Dirs(
+            kitDir,
+            workingPath.toFile(),
+            null
+        ));
+      }
+    }
   }
 }

--- a/client-internal/src/main/java/org/terracotta/angela/client/ClusterTool.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/ClusterTool.java
@@ -127,7 +127,7 @@ public class ClusterTool implements AutoCloseable {
     localKitManager.setupLocalInstall(license, kitInstallationPath, OFFLINE.getBooleanValue());
 
     IgniteCallable<Boolean> callable = () -> Agent.controller.installClusterTool(instanceId, configContext.getHostName(),
-        distribution, license, localKitManager.getKitInstallationName(), securityRootDirectory, tcEnv);
+        distribution, license, localKitManager.getKitInstallationName(), securityRootDirectory, tcEnv, kitInstallationPath);
     boolean isRemoteInstallationSuccessful = IgniteClientHelper.executeRemotely(ignite, configContext.getHostName(), ignitePort, callable);
     if (!isRemoteInstallationSuccessful && (kitInstallationPath == null || !KIT_COPY.getBooleanValue())) {
       try {

--- a/client-internal/src/main/java/org/terracotta/angela/client/ConfigTool.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/ConfigTool.java
@@ -330,7 +330,7 @@ public class ConfigTool implements AutoCloseable {
     localKitManager.setupLocalInstall(license, kitInstallationPath, OFFLINE.getBooleanValue());
 
     IgniteCallable<Boolean> callable = () -> Agent.controller.installConfigTool(instanceId, configContext.getHostName(),
-        distribution, license, localKitManager.getKitInstallationName(), securityRootDirectory, tcEnv);
+        distribution, license, localKitManager.getKitInstallationName(), securityRootDirectory, tcEnv, kitInstallationPath);
     boolean isRemoteInstallationSuccessful = IgniteClientHelper.executeRemotely(ignite, configContext.getHostName(), ignitePort, callable);
     if (!isRemoteInstallationSuccessful && (kitInstallationPath == null || !KIT_COPY.getBooleanValue())) {
       try {

--- a/client-internal/src/main/java/org/terracotta/angela/client/Tms.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/Tms.java
@@ -38,7 +38,6 @@ import org.terracotta.angela.common.util.HostPort;
 import java.util.Collections;
 import java.util.Map;
 
-import static java.util.Collections.singleton;
 import static org.terracotta.angela.common.AngelaProperties.KIT_INSTALLATION_DIR;
 import static org.terracotta.angela.common.AngelaProperties.KIT_INSTALLATION_PATH;
 import static org.terracotta.angela.common.AngelaProperties.OFFLINE;
@@ -152,10 +151,11 @@ public class Tms implements AutoCloseable {
     }
 
     logger.info("Uninstalling TMS from {}", tmsHostname);
+    String kitInstallationPath = getEitherOf(KIT_INSTALLATION_DIR, KIT_INSTALLATION_PATH);
     IgniteClientHelper.executeRemotely(ignite, tmsHostname, ignitePort,
         () -> Agent.controller.uninstallTms(instanceId, tmsConfigurationContext.getDistribution(),
             tmsConfigurationContext.getSecurityConfig(),
-            localKitManager.getKitInstallationName(), tmsHostname));
+            localKitManager.getKitInstallationName(), tmsHostname, kitInstallationPath));
   }
 
   private void install() {
@@ -173,7 +173,7 @@ public class Tms implements AutoCloseable {
 
     logger.info("Attempting to remotely install if distribution already exists on {}", tmsHostname);
     IgniteCallable<Boolean> callable = () -> Agent.controller.installTms(instanceId, tmsHostname, distribution, license,
-        tmsServerSecurityConfig, localKitManager.getKitInstallationName(), tcEnv, singleton(tmsConfigurationContext.getHostname()));
+        tmsServerSecurityConfig, localKitManager.getKitInstallationName(), tcEnv, tmsConfigurationContext.getHostname(), kitInstallationPath);
     boolean isRemoteInstallationSuccessful = kitInstallationPath == null
                                              && IgniteClientHelper.executeRemotely(ignite, tmsHostname, ignitePort, callable);
 

--- a/client-internal/src/main/java/org/terracotta/angela/client/Tsa.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/Tsa.java
@@ -150,7 +150,9 @@ public class Tsa implements AutoCloseable {
     localKitManager.setupLocalInstall(license, kitInstallationPath, OFFLINE.getBooleanValue());
 
     boolean isRemoteInstallationSuccessful;
-    if (kitInstallationPath == null || !KIT_COPY.getBooleanValue()) {
+    if (kitInstallationPath == null || KIT_COPY.getBooleanValue()) {
+      // "kitInstallationPath" is either not provided (=> kit download)
+      // or it is provided but we specifically ask for a kit copy
       logger.info("Attempting to remotely install if distribution already exists on {}", terracottaServer.getHostname());
       isRemoteInstallationSuccessful = IgniteClientHelper.executeRemotely(ignite, terracottaServer.getHostname(), ignitePort,
           () -> Agent.controller.installTsa(instanceId, terracottaServer,
@@ -169,6 +171,8 @@ public class Tsa implements AutoCloseable {
         }
       }
     } else {
+      // We are trying to reuse the "kitInstallationPath" if provided (kitInstallationPath != null)
+      // To end up here, KIT_COPY should be false
       IgniteClientHelper.executeRemotely(ignite, terracottaServer.getHostname(), ignitePort,
           () -> Agent.controller.installTsa(instanceId, terracottaServer,
               license, localKitManager.getKitInstallationName(), distribution, topology, kitInstallationPath));

--- a/client-internal/src/main/java/org/terracotta/angela/client/Voter.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/Voter.java
@@ -157,7 +157,7 @@ public class Voter implements AutoCloseable {
     localKitManager.setupLocalInstall(license, kitInstallationPath, OFFLINE.getBooleanValue());
 
     IgniteCallable<Boolean> callable = () -> Agent.controller.installVoter(instanceId, terracottaVoter, distribution, license,
-        localKitManager.getKitInstallationName(), securityRootDirectory, tcEnv);
+        localKitManager.getKitInstallationName(), securityRootDirectory, tcEnv, kitInstallationPath);
     boolean isRemoteInstallationSuccessful = IgniteClientHelper.executeRemotely(ignite, terracottaVoter.getHostName(), ignitePort, callable);
     if (!isRemoteInstallationSuccessful && (kitInstallationPath == null || !KIT_COPY.getBooleanValue())) {
       try {

--- a/common/src/main/java/org/terracotta/angela/common/tcconfig/License.java
+++ b/common/src/main/java/org/terracotta/angela/common/tcconfig/License.java
@@ -47,10 +47,13 @@ public class License {
 
   public File writeToFile(File dest) {
     File licenseFile = new File(dest, this.filename);
-    try {
-      Files.write(licenseFile.toPath(), licenseContent.getBytes());
-    } catch (IOException ioe) {
-      throw new RuntimeException(ioe);
+    // tests are concurrently using a kit so do not re-write a license file
+    if(!licenseFile.exists()) {
+      try {
+        Files.write(licenseFile.toPath(), licenseContent.getBytes());
+      } catch (IOException ioe) {
+        throw new RuntimeException(ioe);
+      }
     }
     return licenseFile;
   }


### PR DESCRIPTION
- Angela should re-use as is the local kit provided by Gradle in order to leverage Gradle's ability to refresh the content when some changes happen in the project or dependencies

- Angela should not alter a kit provided with `angela.kitInstallationDir`: a local provided kit should be read-only and shouldn't be altered by Angela. If an alteration is needed, up to the test to do this in a local copy. So no license write anymore at the root and no tmc.properties for security updated for example.

Note: This is only valid when "angela.kitInstallationDir" is used

**TESTED ON:** 

- [X] all angela tests on tc-platform pass
- [X] all angela tests on tc-ee pass

**WARNING:**

My knowledge of Angela is limited to its usage in tc-plaforn and EE, where we are mainly interested in pointing to a local kit managed by Gralde/Maven.

I don't know if some other projects are making use of `angela.kitInstallationDir` another way we are in platform and EE.