### PR TITLE
Introduce "angela.java.resolver" and "angela.java.home" system properties to contorl how Angela discovers the JVM to use

### DIFF
--- a/agent-lib/src/main/java/org/terracotta/angela/agent/client/RemoteClientManager.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/agent/client/RemoteClientManager.java
@@ -25,7 +25,6 @@ import org.terracotta.angela.common.ToolExecutionResult;
 import org.terracotta.angela.common.net.PortAllocator;
 import org.terracotta.angela.common.topology.InstanceId;
 import org.terracotta.angela.common.util.ExternalLoggers;
-import org.terracotta.angela.common.util.JavaLocationResolver;
 import org.terracotta.angela.common.util.LogOutputStream;
 import org.terracotta.angela.common.util.OS;
 import org.zeroturnaround.exec.ProcessExecutor;
@@ -51,7 +50,6 @@ import static org.terracotta.angela.common.AngelaProperties.ROOT_DIR;
 public class RemoteClientManager {
 
   private final static Logger logger = LoggerFactory.getLogger(RemoteClientManager.class);
-  private final JavaLocationResolver javaLocationResolver = new JavaLocationResolver();
 
   private static final String CLASSPATH_SUBDIR_NAME = "lib";
   private final File kitInstallationPath;
@@ -69,7 +67,7 @@ public class RemoteClientManager {
   }
 
   public ToolExecutionResult jcmd(int javaPid, TerracottaCommandLineEnvironment tcEnv, String... arguments) {
-    String javaHome = tcEnv.getJavaHome().orElseGet(()->javaLocationResolver.resolveJavaLocation(tcEnv).getHome());
+    String javaHome = tcEnv.getJavaHome();
 
     List<String> cmdLine = new ArrayList<>();
     if (OS.INSTANCE.isWindows()) {
@@ -93,7 +91,7 @@ public class RemoteClientManager {
 
   public int spawnClient(InstanceId instanceId, TerracottaCommandLineEnvironment tcEnv, Collection<String> joinedNodes, int ignitePort, PortAllocator portAllocator) {
     try {
-      String javaHome = tcEnv.getJavaHome().orElseGet(()->javaLocationResolver.resolveJavaLocation(tcEnv).getHome());
+      String javaHome = tcEnv.getJavaHome();
 
       final AtomicBoolean started = new AtomicBoolean(false);
       List<String> cmdLine = new ArrayList<>();

--- a/client-internal/src/main/java/org/terracotta/angela/client/remote/agent/SshRemoteAgentLauncher.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/remote/agent/SshRemoteAgentLauncher.java
@@ -252,7 +252,7 @@ public class SshRemoteAgentLauncher implements RemoteAgentLauncher {
     }
     byte[] bytes = ((ByteArrayOutputStream) localFile.getOutputStream()).toByteArray();
     JavaLocationResolver javaLocationResolver = new JavaLocationResolver(new ByteArrayInputStream(bytes));
-    List<JDK> jdks = javaLocationResolver.resolveJavaLocations(tcEnv, false);
+    List<JDK> jdks = javaLocationResolver.resolveJavaLocations(tcEnv.getJavaVersion(), tcEnv.getJavaVendors(), false);
     // check JDK validity remotely
     for (JDK jdk : jdks) {
       String remoteHome = jdk.getHome();

--- a/common/src/main/java/org/terracotta/angela/common/AngelaProperties.java
+++ b/common/src/main/java/org/terracotta/angela/common/AngelaProperties.java
@@ -64,6 +64,16 @@ public enum AngelaProperties {
   VOTER_FULL_LOGGING("angela.voter.fullLogging", "false"),
 
   // jdk properties to be used by Angela for running processes
+  /**
+   * {@code angela.java.resolver} determines how Angela computes the JAVA_HOME env variable that it will set for all its sub-processes.
+   * The default value is {@code toolchain}.
+   * <ul>
+   *   <li>{@code toolchain}: Angela will compute the JAVA_HOME by discovering paths in the Maven toolchain file, entries being filtered by {@code angela.java.vendor} and {@code angela.java.version}.</li>
+   *   <li>{@code user}: Angela will compute the JAVA_HOME by picking the value of {@code angela.java.home} which can be set by the user. If the user does not specify {@code angela.java.home}, then the {@code java.home} system property is used, which should be the JVM running the current code. {@code angela.java.vendor} and {@code angela.java.version} will not be used in this mode.</li>
+   * </ul>
+   */
+  JAVA_RESOLVER("angela.java.resolver", "toolchain"),
+  JAVA_HOME("angela.java.home", System.getProperty("java.home")),
   JAVA_VENDOR("angela.java.vendor", "zulu"),
   JAVA_VERSION("angela.java.version", "1.8"),
   JAVA_OPTS("angela.java.opts", "-Djdk.security.allowNonCaAnchor=false"),

--- a/common/src/main/java/org/terracotta/angela/common/TerracottaCommandLineEnvironment.java
+++ b/common/src/main/java/org/terracotta/angela/common/TerracottaCommandLineEnvironment.java
@@ -19,21 +19,25 @@ package org.terracotta.angela.common;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terracotta.angela.common.util.JDK;
 import org.terracotta.angela.common.util.JavaLocationResolver;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 import static java.util.Collections.unmodifiableSet;
 import static java.util.Objects.requireNonNull;
+import static org.terracotta.angela.common.AngelaProperties.JAVA_HOME;
 import static org.terracotta.angela.common.AngelaProperties.JAVA_OPTS;
+import static org.terracotta.angela.common.AngelaProperties.JAVA_RESOLVER;
 import static org.terracotta.angela.common.AngelaProperties.JAVA_VENDOR;
 import static org.terracotta.angela.common.AngelaProperties.JAVA_VERSION;
 
@@ -46,18 +50,31 @@ public class TerracottaCommandLineEnvironment {
   public static final TerracottaCommandLineEnvironment DEFAULT;
 
   static {
-    String version = JAVA_VERSION.getValue();
-    // Important - Use a LinkedHashSet to preserve the order of preferred Java vendor
-    Set<String> vendors = JAVA_VENDOR.getValue().equals("") ? new LinkedHashSet<>() : singleton(JAVA_VENDOR.getValue());
-    // Important - Use a LinkedHashSet to preserve the order of opts, as some opts are position-sensitive
-    Set<String> opts = JAVA_OPTS.getValue().equals("") ? new LinkedHashSet<>() : singleton(JAVA_OPTS.getValue());
-    DEFAULT = new TerracottaCommandLineEnvironment(Optional.empty(), version, vendors, opts);
+    switch (JAVA_RESOLVER.getValue()) {
+      case "toolchain": {
+        String version = JAVA_VERSION.getValue();
+        // Important - Use a LinkedHashSet to preserve the order of preferred Java vendor
+        Set<String> vendors = JAVA_VENDOR.getValue().equals("") ? new LinkedHashSet<>() : singleton(JAVA_VENDOR.getValue());
+        // Important - Use a LinkedHashSet to preserve the order of opts, as some opts are position-sensitive
+        Set<String> opts = JAVA_OPTS.getValue().equals("") ? new LinkedHashSet<>() : singleton(JAVA_OPTS.getValue());
+        DEFAULT = new TerracottaCommandLineEnvironment(version, vendors, opts);
+        break;
+      }
+      case "user": {
+        Set<String> opts = JAVA_OPTS.getValue().equals("") ? new LinkedHashSet<>() : singleton(JAVA_OPTS.getValue());
+        DEFAULT = new TerracottaCommandLineEnvironment(JAVA_HOME.getValue(), "", emptySet(), opts);
+        break;
+      }
+      default:
+        throw new AssertionError("Unsupported value for '" + JAVA_RESOLVER.getPropertyName() + "': " + JAVA_RESOLVER.getValue());
+    }
   }
 
-  private final Optional<String> javaHome;
+  private final String javaHome;
   private final String javaVersion;
   private final Set<String> javaVendors;
   private final Set<String> javaOpts;
+  private final JavaLocationResolver javaLocationResolver;
 
   /**
    * Create a new instance that contains whatever is necessary to build a JVM command line, minus classpath and main class.
@@ -67,12 +84,18 @@ public class TerracottaCommandLineEnvironment {
    * @param javaOpts    some command line arguments to give to the JVM, like -Xmx2G, -XX:Whatever or -Dsomething=abc.
    *                    Can be empty if no JVM argument is needed.
    */
-  private TerracottaCommandLineEnvironment(Optional<String> javaHome, String javaVersion, Set<String> javaVendors, Set<String> javaOpts) {
+  private TerracottaCommandLineEnvironment(String javaHome, String javaVersion, Set<String> javaVendors, Set<String> javaOpts) {
     validate(javaVersion, javaVendors, javaOpts);
     this.javaHome = javaHome;
     this.javaVersion = javaVersion;
     this.javaVendors = unmodifiableSet(new LinkedHashSet<>(javaVendors));
     this.javaOpts = unmodifiableSet(new LinkedHashSet<>(javaOpts));
+    // javaHome ? "user" resolver. Otherwise: "toolchain" resolver
+    this.javaLocationResolver = javaHome != null ? null : new JavaLocationResolver();
+  }
+
+  private TerracottaCommandLineEnvironment(String javaVersion, Set<String> javaVendors, Set<String> javaOpts) {
+    this(null, javaVersion, javaVendors, javaOpts);
   }
 
   private static void validate(String javaVersion, Set<String> javaVendors, Set<String> javaOpts) {
@@ -102,11 +125,17 @@ public class TerracottaCommandLineEnvironment {
   }
 
   public TerracottaCommandLineEnvironment withJavaHome(String jdkHome) {
-    return new TerracottaCommandLineEnvironment(Optional.of(jdkHome), javaVersion, javaVendors, javaOpts);
+    return new TerracottaCommandLineEnvironment(requireNonNull(jdkHome), javaVersion, javaVendors, javaOpts);
   }
 
-  public Optional<String> getJavaHome() {
-    return javaHome;
+  public String getJavaHome() {
+    return Optional.ofNullable(javaHome).orElseGet(() -> {
+      List<JDK> jdks = javaLocationResolver.resolveJavaLocations(getJavaVersion(), getJavaVendors(), true);
+      if (jdks.size() > 1) {
+        LOGGER.warn("Multiple matching java versions found: {} - using the 1st one", jdks);
+      }
+      return jdks.get(0).getHome();
+    });
   }
 
   public String getJavaVersion() {
@@ -121,15 +150,11 @@ public class TerracottaCommandLineEnvironment {
     return javaOpts;
   }
 
-  public Map<String, String> buildEnv(JavaLocationResolver javaLocationResolver) {
-    return buildEnv(javaLocationResolver, Collections.emptyMap());
-  }
-
-  public Map<String, String> buildEnv(JavaLocationResolver javaLocationResolver, Map<String, String> overrides) {
+  public Map<String, String> buildEnv(Map<String, String> overrides) {
     LOGGER.info("overrides={}", overrides);
 
     Map<String, String> env = new HashMap<>();
-    String javaHome = getJavaHome().orElseGet(() -> javaLocationResolver.resolveJavaLocation(this).getHome());
+    String javaHome = getJavaHome();
     env.put("JAVA_HOME", javaHome);
 
     Set<String> javaOpts = getJavaOpts();

--- a/common/src/main/java/org/terracotta/angela/common/distribution/Distribution102Controller.java
+++ b/common/src/main/java/org/terracotta/angela/common/distribution/Distribution102Controller.java
@@ -83,7 +83,7 @@ public class Distribution102Controller extends DistributionController {
   public TerracottaServerInstanceProcess createTsa(TerracottaServer terracottaServer, File kitDir, File workingDir,
                                                    Topology topology, Map<ServerSymbolicName, Integer> proxiedPorts,
                                                    TerracottaCommandLineEnvironment tcEnv, Map<String, String> envOverrides, List<String> startUpArgs) {
-    Map<String, String> env = tcEnv.buildEnv(javaLocationResolver, envOverrides);
+    Map<String, String> env = tcEnv.buildEnv(envOverrides);
     AtomicReference<TerracottaServerState> stateRef = new AtomicReference<>(TerracottaServerState.STOPPED);
     AtomicInteger javaPid = new AtomicInteger(-1);
 
@@ -158,7 +158,7 @@ public class Distribution102Controller extends DistributionController {
 
   @Override
   public TerracottaManagementServerInstanceProcess startTms(File kitDir, File workingDir, TerracottaCommandLineEnvironment tcEnv, Map<String, String> envOverrides) {
-    Map<String, String> env = tcEnv.buildEnv(javaLocationResolver, envOverrides);
+    Map<String, String> env = tcEnv.buildEnv(envOverrides);
 
     AtomicReference<TerracottaManagementServerState> stateRef = new AtomicReference<>(TerracottaManagementServerState.STOPPED);
     AtomicInteger javaPid = new AtomicInteger(-1);
@@ -304,7 +304,7 @@ public class Distribution102Controller extends DistributionController {
       logger.info("Cluster tool command: {}", command);
       ProcessResult processResult = new ProcessExecutor(command)
           .directory(workingDir)
-          .environment(env.buildEnv(javaLocationResolver, envOverrides))
+          .environment(env.buildEnv(envOverrides))
           .readOutput(true)
           .redirectOutputAlsoTo(Slf4jStream.of(ExternalLoggers.clusterToolLogger).asInfo())
           .redirectErrorStream(true)

--- a/common/src/main/java/org/terracotta/angela/common/distribution/Distribution107Controller.java
+++ b/common/src/main/java/org/terracotta/angela/common/distribution/Distribution107Controller.java
@@ -80,7 +80,7 @@ public class Distribution107Controller extends DistributionController {
   public TerracottaServerInstanceProcess createTsa(TerracottaServer terracottaServer, File kitDir, File workingDir,
                                                    Topology topology, Map<ServerSymbolicName, Integer> proxiedPorts,
                                                    TerracottaCommandLineEnvironment tcEnv, Map<String, String> envOverrides, List<String> startUpArgs) {
-    Map<String, String> env = tcEnv.buildEnv(javaLocationResolver, envOverrides);
+    Map<String, String> env = tcEnv.buildEnv(envOverrides);
     AtomicReference<TerracottaServerState> stateRef = new AtomicReference<>(TerracottaServerState.STOPPED);
     AtomicInteger javaPid = new AtomicInteger(-1);
 
@@ -136,7 +136,7 @@ public class Distribution107Controller extends DistributionController {
 
   @Override
   public TerracottaManagementServerInstanceProcess startTms(File kitDir, File workingDir, TerracottaCommandLineEnvironment tcEnv, Map<String, String> envOverrides) {
-    Map<String, String> env = tcEnv.buildEnv(javaLocationResolver, envOverrides);
+    Map<String, String> env = tcEnv.buildEnv(envOverrides);
 
     AtomicReference<TerracottaManagementServerState> stateRef = new AtomicReference<>(TerracottaManagementServerState.STOPPED);
     AtomicInteger javaPid = new AtomicInteger(-1);
@@ -190,7 +190,7 @@ public class Distribution107Controller extends DistributionController {
   @Override
   public TerracottaVoterInstanceProcess startVoter(TerracottaVoter terracottaVoter, File kitDir, File workingDir,
                                                    SecurityRootDirectory securityDir, TerracottaCommandLineEnvironment tcEnv, Map<String, String> envOverrides) {
-    Map<String, String> env = tcEnv.buildEnv(javaLocationResolver, envOverrides);
+    Map<String, String> env = tcEnv.buildEnv(envOverrides);
 
     AtomicReference<TerracottaVoterState> stateRef = new AtomicReference<>(TerracottaVoterState.STOPPED);
     AtomicInteger javaPid = new AtomicInteger(-1);
@@ -252,7 +252,7 @@ public class Distribution107Controller extends DistributionController {
     try {
       ProcessResult processResult = new ProcessExecutor(createClusterToolCommand(kitDir, workingDir, securityDir, arguments))
           .directory(workingDir)
-          .environment(env.buildEnv(javaLocationResolver, envOverrides))
+          .environment(env.buildEnv(envOverrides))
           .readOutput(true)
           .redirectOutputAlsoTo(Slf4jStream.of(ExternalLoggers.clusterToolLogger).asInfo())
           .redirectErrorStream(true)
@@ -466,7 +466,7 @@ public class Distribution107Controller extends DistributionController {
       LOGGER.info("Config tool command: {}", command);
       ProcessResult processResult = new ProcessExecutor(command)
           .directory(workingDir)
-          .environment(env.buildEnv(javaLocationResolver, envOverrides))
+          .environment(env.buildEnv(envOverrides))
           .readOutput(true)
           .redirectOutputAlsoTo(Slf4jStream.of(ExternalLoggers.configToolLogger).asInfo())
           .redirectErrorStream(true)

--- a/common/src/main/java/org/terracotta/angela/common/distribution/Distribution43Controller.java
+++ b/common/src/main/java/org/terracotta/angela/common/distribution/Distribution43Controller.java
@@ -114,7 +114,7 @@ public class Distribution43Controller extends DistributionController {
         serverLogOutputStream.andTriggerOn(compile("^.*(WARN|ERROR).*$"), mr -> ExternalLoggers.tsaLogger.info("[{}] {}", terracottaServer.getServerSymbolicName().getSymbolicName(), mr.group()));
 
     // add an identifiable ID to the JVM's system properties
-    Map<String, String> env = tcEnv.buildEnv(javaLocationResolver, envOverrides);
+    Map<String, String> env = tcEnv.buildEnv(envOverrides);
     env.compute("JAVA_OPTS", (key, value) -> {
       String prop = " -Dangela.processIdentifier=" + terracottaServer.getId();
       return value == null ? prop : value + prop;
@@ -136,7 +136,7 @@ public class Distribution43Controller extends DistributionController {
   }
 
   private Number findWithJcmdJavaPidOf(String serverUuid, TerracottaCommandLineEnvironment tcEnv) {
-    String javaHome = tcEnv.getJavaHome().orElseGet(() -> javaLocationResolver.resolveJavaLocation(tcEnv).getHome());
+    String javaHome = tcEnv.getJavaHome();
 
     List<String> cmdLine = new ArrayList<>();
     if (OS.INSTANCE.isWindows()) {

--- a/common/src/main/java/org/terracotta/angela/common/distribution/DistributionController.java
+++ b/common/src/main/java/org/terracotta/angela/common/distribution/DistributionController.java
@@ -31,7 +31,6 @@ import org.terracotta.angela.common.tcconfig.SecurityRootDirectory;
 import org.terracotta.angela.common.tcconfig.ServerSymbolicName;
 import org.terracotta.angela.common.tcconfig.TerracottaServer;
 import org.terracotta.angela.common.topology.Topology;
-import org.terracotta.angela.common.util.JavaLocationResolver;
 import org.terracotta.angela.common.util.OS;
 import org.terracotta.angela.common.util.ProcessUtil;
 import org.terracotta.angela.common.util.RetryUtils;
@@ -56,9 +55,6 @@ public abstract class DistributionController {
 
   protected final Distribution distribution;
 
-  protected final JavaLocationResolver javaLocationResolver = new JavaLocationResolver();
-
-
   DistributionController(Distribution distribution) {
     this.distribution = distribution;
   }
@@ -69,7 +65,7 @@ public abstract class DistributionController {
       return new ToolExecutionResult(-1, Collections.singletonList("PID of java process could not be figured out"));
     }
 
-    String javaHome = tcEnv.getJavaHome().orElseGet(() -> javaLocationResolver.resolveJavaLocation(tcEnv).getHome());
+    String javaHome = tcEnv.getJavaHome();
 
     List<String> cmdLine = new ArrayList<>();
     if (OS.INSTANCE.isWindows()) {

--- a/common/src/main/java/org/terracotta/angela/common/util/JavaLocationResolver.java
+++ b/common/src/main/java/org/terracotta/angela/common/util/JavaLocationResolver.java
@@ -17,9 +17,6 @@
 
 package org.terracotta.angela.common.util;
 
-import org.terracotta.angela.common.TerracottaCommandLineEnvironment;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -48,8 +45,6 @@ import java.util.stream.Collectors;
 
 public class JavaLocationResolver {
 
-  private final static Logger LOGGER = LoggerFactory.getLogger(JavaLocationResolver.class);
-
   private final List<JDK> jdks;
 
   public JavaLocationResolver() {
@@ -65,33 +60,11 @@ public class JavaLocationResolver {
     }
   }
 
-  public JDK resolveJavaLocation(TerracottaCommandLineEnvironment tcEnv) {
-    List<JDK> jdks = resolveJavaLocations(tcEnv.getJavaVersion(), tcEnv.getJavaVendors(), true);
-    if (jdks.size() > 1) {
-      LOGGER.info("Multiple matching java versions found: {} - using the 1st one", jdks);
-    }
-    return jdks.get(0);
-  }
-
-  public List<JDK> resolveJavaLocations(TerracottaCommandLineEnvironment tcEnv, boolean checkValidity) {
-    return resolveJavaLocations(tcEnv.getJavaVersion(), tcEnv.getJavaVendors(), checkValidity);
-  }
-
-  List<JDK> resolveJavaLocations(String version, Set<String> vendors, boolean checkValidity) {
+  public List<JDK> resolveJavaLocations(String version, Set<String> vendors, boolean checkValidity) {
     List<JDK> list = jdks.stream()
         .filter(jdk -> !checkValidity || jdk.isValid())
         .filter(jdk -> version.isEmpty() || version.equals(jdk.getVersion()))
-        .filter(jdk -> {
-          if (vendors.isEmpty()) {
-            return true;
-          }
-          for (String vendor : vendors) {
-            if (vendor.equalsIgnoreCase(jdk.getVendor())) {
-              return true;
-            }
-          }
-          return false;
-        })
+        .filter(jdk -> vendors.isEmpty() || vendors.stream().anyMatch(v -> v.equalsIgnoreCase(jdk.getVendor())))
         .collect(Collectors.toList());
     if (list.isEmpty()) {
       String message = "Missing JDK with version [" + version + "]";


### PR DESCRIPTION
 - to allow Angela to reuse the exact same JVM used for testing locally
 - to allow Angela to use a different JVM to spawn proceses than the one running tests
 - to allow Angela to discover JVM like before with a toolchain
 This removes the dependency on the Maven toolchain file when we are doing local testing