### PR TITLE
Angela should not expect and validate the exit status of the processes it calls.

### DIFF
--- a/common/src/main/java/org/terracotta/angela/common/distribution/Distribution102Controller.java
+++ b/common/src/main/java/org/terracotta/angela/common/distribution/Distribution102Controller.java
@@ -308,7 +308,6 @@ public class Distribution102Controller extends DistributionController {
           .readOutput(true)
           .redirectOutputAlsoTo(Slf4jStream.of(ExternalLoggers.clusterToolLogger).asInfo())
           .redirectErrorStream(true)
-          .exitValue(0)
           .execute();
       return new ToolExecutionResult(processResult.getExitValue(), processResult.getOutput().getLines());
     } catch (Exception e) {

--- a/common/src/main/java/org/terracotta/angela/common/distribution/Distribution107Controller.java
+++ b/common/src/main/java/org/terracotta/angela/common/distribution/Distribution107Controller.java
@@ -256,7 +256,6 @@ public class Distribution107Controller extends DistributionController {
           .readOutput(true)
           .redirectOutputAlsoTo(Slf4jStream.of(ExternalLoggers.clusterToolLogger).asInfo())
           .redirectErrorStream(true)
-          .exitValue(0)
           .execute();
       return new ToolExecutionResult(processResult.getExitValue(), processResult.getOutput().getLines());
     } catch (Exception e) {
@@ -470,7 +469,6 @@ public class Distribution107Controller extends DistributionController {
           .readOutput(true)
           .redirectOutputAlsoTo(Slf4jStream.of(ExternalLoggers.configToolLogger).asInfo())
           .redirectErrorStream(true)
-          .exitValue(0)
           .execute();
       return new ToolExecutionResult(processResult.getExitValue(), processResult.getOutput().getLines());
     } catch (Exception e) {

--- a/integration-test/src/test/java/org/terracotta/angela/ConfigToolTest.java
+++ b/integration-test/src/test/java/org/terracotta/angela/ConfigToolTest.java
@@ -26,8 +26,11 @@ import org.terracotta.angela.common.distribution.Distribution;
 import org.terracotta.angela.common.tcconfig.TerracottaServer;
 import org.terracotta.angela.common.topology.Topology;
 
-import static org.junit.Assert.fail;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
 import static org.terracotta.angela.client.config.custom.CustomConfigurationContext.customConfigurationContext;
+import static org.terracotta.angela.client.support.hamcrest.AngelaMatchers.successful;
 import static org.terracotta.angela.common.TerracottaConfigTool.configTool;
 import static org.terracotta.angela.common.distribution.Distribution.distribution;
 import static org.terracotta.angela.common.dynamic_cluster.Stripe.stripe;
@@ -57,12 +60,8 @@ public class ConfigToolTest {
       tsa.startAll();
       ConfigTool configTool = factory.configTool();
 
-      try {
-        configTool.executeCommand("non-existent-command");
-        fail("Expected config tool invocation to fail as the command doesn't exist");
-      } catch (Exception e) {
-        // expected
-      }
+      ToolExecutionResult result = configTool.executeCommand("non-existent-command");
+      assertThat(result, is(not(successful())));
     }
   }
 


### PR DESCRIPTION
This is up to the test to assert whether the invocation has to be successful or not.
`exitValue(0)` was preventing the test from asserting that a command has to fail because angela was directly throwing