### PR TITLE
Need to fail eagerly when pre-program commands are failing because sadly method does not return any invocation status

### DIFF
--- a/client-internal/src/main/java/org/terracotta/angela/client/ClusterTool.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/ClusterTool.java
@@ -85,7 +85,10 @@ public class ClusterTool implements AutoCloseable {
     }
     List<String> command = new ArrayList<>(Arrays.asList("configure", "-n", clusterName));
     IgniteCallable<ToolExecutionResult> callable = () -> Agent.controller.configure(instanceId, tsa.getTsaConfigurationContext().getTopology(), tsa.updateToProxiedPorts(), license, securityRootDirectory, tcEnv, env, command);
-    IgniteClientHelper.executeRemotely(ignite, configContext.getHostName(), ignitePort, callable);
+    ToolExecutionResult result = IgniteClientHelper.executeRemotely(ignite, configContext.getHostName(), ignitePort, callable);
+    if(result.getExitStatus() != 0) {
+      throw new IllegalStateException("Failed to execute cluster-tool configure:\n" + result.toString());
+    }
     return this;
   }
 

--- a/client-internal/src/main/java/org/terracotta/angela/client/ConfigTool.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/ConfigTool.java
@@ -312,7 +312,10 @@ public class ConfigTool implements AutoCloseable {
     }
     List<String> args = new ArrayList<>(Arrays.asList("activate", "-n", clusterName, "-s", terracottaServer.getHostPort()));
     IgniteCallable<ToolExecutionResult> callable = () -> Agent.controller.activate(instanceId, license, securityRootDirectory, tcEnv, env, args);
-    IgniteClientHelper.executeRemotely(ignite, configContext.getHostName(), ignitePort, callable);
+    ToolExecutionResult result = IgniteClientHelper.executeRemotely(ignite, configContext.getHostName(), ignitePort, callable);
+    if(result.getExitStatus() != 0) {
+      throw new IllegalStateException("Failed to execute config-tool activate:\n" + result.toString());
+    }
     return this;
   }
 


### PR DESCRIPTION
this is a fix for previous PR, which was causing a test to fail in angela-ee because pre-defined commands require the exist status to be 0 always... And there is sadly no way to give control to the user to value of this status if the sub command failed.