### PR TITLE
Forcing JNA for descendant projects too

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -30,6 +30,15 @@
   <artifactId>angela-common</artifactId>
 
   <dependencies>
+    <!-- important to keep this dependency override here -->
+    <dependency>
+      <groupId>net.java.dev.jna</groupId>
+      <artifactId>jna</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>net.java.dev.jna</groupId>
+      <artifactId>jna-platform</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.apache.ignite</groupId>
       <artifactId>ignite-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -179,12 +179,30 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna-platform</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
         <groupId>org.zeroturnaround</groupId>
         <artifactId>zt-exec</artifactId>
         <version>${zt-exec.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna-platform</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -214,6 +232,11 @@
       <dependency>
         <groupId>net.java.dev.jna</groupId>
         <artifactId>jna</artifactId>
+        <version>${jna.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>net.java.dev.jna</groupId>
+        <artifactId>jna-platform</artifactId>
         <version>${jna.version}</version>
       </dependency>
     </dependencies>


### PR DESCRIPTION
Taken out from #139

This is to control the jNA version (to be updated with ZT libs or JDK/OS version changes) and to avoid collisions in descendant projects and