### PR TITLE
Fix: Use the machine hostname by default instead of localhost to bett…

### DIFF
--- a/agent-lib/src/main/java/org/terracotta/angela/agent/Agent.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/agent/Agent.java
@@ -31,6 +31,7 @@ import org.terracotta.angela.common.AngelaProperties;
 import org.terracotta.angela.common.net.DefaultPortAllocator;
 import org.terracotta.angela.common.util.AngelaVersion;
 import org.terracotta.angela.common.util.IgniteCommonHelper;
+import org.terracotta.angela.common.util.IpUtils;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -87,7 +88,7 @@ public class Agent {
 
   @Override
   public String toString() {
-    return ignite == null ? "local" : ("localhost:" + igniteDiscoveryPort);
+    return ignite == null ? "local" : (IpUtils.getHostName() + ":" + igniteDiscoveryPort);
   }
 
   public static void main(String[] args) {

--- a/agent-lib/src/main/java/org/terracotta/angela/agent/kit/RemoteKitManager.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/agent/kit/RemoteKitManager.java
@@ -78,10 +78,6 @@ public class RemoteKitManager extends KitManager {
     }
   }
 
-  public Path getKitDir() {
-    return kitPath;
-  }
-
   public boolean isKitAvailable() {
     logger.debug("verifying if the extracted kit is already available locally to setup an install");
     if (!Files.isDirectory(kitInstallationPath)) {

--- a/client-internal/src/main/java/org/terracotta/angela/client/AngelaOrchestrator.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/AngelaOrchestrator.java
@@ -27,6 +27,7 @@ import org.terracotta.angela.common.net.DefaultPortAllocator;
 import org.terracotta.angela.common.net.PortAllocator;
 import org.terracotta.angela.common.tcconfig.TerracottaServer;
 import org.terracotta.angela.common.topology.Topology;
+import org.terracotta.angela.common.util.IpUtils;
 
 import java.util.Collections;
 import java.util.List;
@@ -48,7 +49,7 @@ public class AngelaOrchestrator implements AutoCloseable {
       PortAllocator.PortReservation reservation = portAllocator.reserve(2);
       int igniteDiscoveryPort = reservation.next();
       int igniteComPort = reservation.next();
-      this.localAgent = Agent.startCluster(Collections.singleton("localhost:" + igniteDiscoveryPort), "localhost:" + igniteDiscoveryPort, igniteDiscoveryPort, igniteComPort);
+      this.localAgent = Agent.startCluster(Collections.singleton(IpUtils.getHostName() + ":" + igniteDiscoveryPort), IpUtils.getHostName() + ":" + igniteDiscoveryPort, igniteDiscoveryPort, igniteComPort);
     }
 
     // Since Ignite deported closures require to access a static instance of an agent (Agent.getInstance())

--- a/client-internal/src/main/java/org/terracotta/angela/client/ClusterFactory.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/ClusterFactory.java
@@ -31,6 +31,7 @@ import org.terracotta.angela.common.metrics.HardwareMetric;
 import org.terracotta.angela.common.metrics.MonitoringCommand;
 import org.terracotta.angela.common.net.PortAllocator;
 import org.terracotta.angela.common.topology.InstanceId;
+import org.terracotta.angela.common.util.IpUtils;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
@@ -79,7 +80,7 @@ public class ClusterFactory implements AutoCloseable {
     this.remoteAgentLauncher = configurationContext.remoting().buildRemoteAgentLauncher();
     this.localAgent = agent;
     this.portAllocator = portAllocator;
-    agentsInstance.put("localhost", "localhost:" + localAgent.getIgniteDiscoveryPort());
+    agentsInstance.put(IpUtils.getHostName(), IpUtils.getHostName() + ":" + localAgent.getIgniteDiscoveryPort());
   }
 
   private InstanceId init(String type, Collection<String> hostnames) {

--- a/client-internal/src/main/java/org/terracotta/angela/client/config/custom/CustomTmsConfigurationContext.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/config/custom/CustomTmsConfigurationContext.java
@@ -20,11 +20,12 @@ import org.terracotta.angela.common.TerracottaCommandLineEnvironment;
 import org.terracotta.angela.common.distribution.Distribution;
 import org.terracotta.angela.common.tcconfig.License;
 import org.terracotta.angela.common.tms.security.config.TmsServerSecurityConfig;
+import org.terracotta.angela.common.util.IpUtils;
 
 public class CustomTmsConfigurationContext implements TmsConfigurationContext {
   private Distribution distribution;
   private License license;
-  private String hostname;
+  private String hostname = IpUtils.getHostName();
   private TmsServerSecurityConfig securityConfig;
   private TerracottaCommandLineEnvironment terracottaCommandLineEnvironment = TerracottaCommandLineEnvironment.DEFAULT;
 

--- a/client-internal/src/main/java/org/terracotta/angela/client/net/ClientToServerDisruptor.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/net/ClientToServerDisruptor.java
@@ -25,6 +25,7 @@ import org.terracotta.angela.common.tcconfig.ServerSymbolicName;
 import org.terracotta.angela.common.tcconfig.TerracottaServer;
 import org.terracotta.angela.common.topology.Topology;
 import org.terracotta.angela.common.util.HostPort;
+import org.terracotta.angela.common.util.IpUtils;
 
 import java.net.InetSocketAddress;
 import java.net.URI;
@@ -57,8 +58,8 @@ public class ClientToServerDisruptor implements Disruptor {
   ClientToServerDisruptor(Topology topology, Consumer<Disruptor> closeHook, Map<ServerSymbolicName, Integer> proxiedTsaPorts) {
     this.closeHook = closeHook;
     for (TerracottaServer server : topology.getServers()) {
-      final InetSocketAddress clientEndPoint = DISRUPTION_PROVIDER.isProxyBased() ? null : new InetSocketAddress("localhost", -1);
-      final InetSocketAddress proxyEndPoint = DISRUPTION_PROVIDER.isProxyBased() ? new InetSocketAddress("localhost", proxiedTsaPorts
+      final InetSocketAddress clientEndPoint = DISRUPTION_PROVIDER.isProxyBased() ? null : new InetSocketAddress(IpUtils.getHostName(), -1);
+      final InetSocketAddress proxyEndPoint = DISRUPTION_PROVIDER.isProxyBased() ? new InetSocketAddress(IpUtils.getHostName(), proxiedTsaPorts
           .get(server.getServerSymbolicName())) : null;
       final InetSocketAddress serverEndPoint = new InetSocketAddress(server.getHostname(), server.getTsaPort());
 

--- a/client-internal/src/main/java/org/terracotta/angela/client/util/IgniteClientHelper.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/util/IgniteClientHelper.java
@@ -32,6 +32,7 @@ import org.terracotta.angela.common.topology.InstanceId;
 import org.terracotta.angela.common.util.AngelaVersion;
 import org.terracotta.angela.common.util.FileMetadata;
 import org.terracotta.angela.common.util.IgniteCommonHelper;
+import org.terracotta.angela.common.util.IpUtils;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -113,13 +114,12 @@ public class IgniteClientHelper {
             " but the expected version is [" + AngelaVersion.getAngelaVersion() + "]");
       }
     } catch (IgniteException e) {
-      e.printStackTrace();
       throw new IllegalStateException("Node with name '" + nodeName + "' not found in the cluster", e);
     }
   }
 
   private static String getNodeName(String nodeName, int ignitePort) {
-    return nodeName + ":" + ignitePort;
+    return (IpUtils.isLocal(nodeName) ? IpUtils.getHostName() : nodeName) + ":" + ignitePort;
   }
 
   public static void uploadKit(Ignite ignite, String hostname, int ignitePort, InstanceId instanceId, Distribution distribution,

--- a/common/src/main/java/org/terracotta/angela/common/TerracottaClusterTool.java
+++ b/common/src/main/java/org/terracotta/angela/common/TerracottaClusterTool.java
@@ -15,6 +15,8 @@
  */
 package org.terracotta.angela.common;
 
+import org.terracotta.angela.common.util.IpUtils;
+
 public class TerracottaClusterTool {
   private final String id;
   private final String hostName;
@@ -26,6 +28,10 @@ public class TerracottaClusterTool {
 
   public static TerracottaClusterTool clusterTool(String id, String hostName) {
     return new TerracottaClusterTool(id, hostName);
+  }
+
+  public static TerracottaClusterTool clusterTool(String id) {
+    return new TerracottaClusterTool(id, IpUtils.getHostName());
   }
 
   public String getId() {

--- a/common/src/main/java/org/terracotta/angela/common/TerracottaConfigTool.java
+++ b/common/src/main/java/org/terracotta/angela/common/TerracottaConfigTool.java
@@ -15,6 +15,8 @@
  */
 package org.terracotta.angela.common;
 
+import org.terracotta.angela.common.util.IpUtils;
+
 public class TerracottaConfigTool {
   private final String id;
   private final String hostName;
@@ -26,6 +28,10 @@ public class TerracottaConfigTool {
 
   public static TerracottaConfigTool configTool(String id, String hostName) {
     return new TerracottaConfigTool(id, hostName);
+  }
+
+  public static TerracottaConfigTool configTool(String id) {
+    return new TerracottaConfigTool(id, IpUtils.getHostName());
   }
 
   public String getId() {

--- a/common/src/main/java/org/terracotta/angela/common/TerracottaVoter.java
+++ b/common/src/main/java/org/terracotta/angela/common/TerracottaVoter.java
@@ -15,6 +15,8 @@
  */
 package org.terracotta.angela.common;
 
+import org.terracotta.angela.common.util.IpUtils;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -40,6 +42,14 @@ public class TerracottaVoter {
 
   public static TerracottaVoter dcVoter(String id, String hostName, String... serverNames) {
     return new TerracottaVoter(id, hostName, emptyList(), Arrays.asList(serverNames));
+  }
+
+  public static TerracottaVoter localVoter(String id, String... hostPorts) {
+    return new TerracottaVoter(id, IpUtils.getHostName(), Arrays.asList(hostPorts), emptyList());
+  }
+
+  public static TerracottaVoter localDCVoter(String id, String... serverNames) {
+    return new TerracottaVoter(id, IpUtils.getHostName(), emptyList(), Arrays.asList(serverNames));
   }
 
   public String getId() {

--- a/common/src/main/java/org/terracotta/angela/common/clientconfig/ClientArrayConfig.java
+++ b/common/src/main/java/org/terracotta/angela/common/clientconfig/ClientArrayConfig.java
@@ -15,6 +15,8 @@
  */
 package org.terracotta.angela.common.clientconfig;
 
+import org.terracotta.angela.common.util.IpUtils;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -33,6 +35,14 @@ public class ClientArrayConfig {
     return new ClientArrayConfig();
   }
 
+  public ClientArrayConfig named(String symbolicName) {
+    return host(symbolicName, IpUtils.getHostName());
+  }
+
+  /**
+   * @deprecated Use {@link #named(String)} or {{@link #host(String, String)}} instead
+   */
+  @Deprecated
   public ClientArrayConfig host(String hostname) {
     return host(hostname, hostname);
   }
@@ -53,8 +63,16 @@ public class ClientArrayConfig {
 
   public ClientArrayConfig hostSerie(int serieLength, String hostname) {
     for (int i = 0; i < serieLength; i++) {
-      String clientSymbolicName =  hostname + "-" + i;
+      String clientSymbolicName = hostname + "-" + i;
       host(clientSymbolicName, hostname);
+    }
+    return this;
+  }
+
+  public ClientArrayConfig hostSerie(int serieLength) {
+    for (int i = 0; i < serieLength; i++) {
+      String clientSymbolicName = IpUtils.getHostName() + "-" + i;
+      host(clientSymbolicName, IpUtils.getHostName());
     }
     return this;
   }

--- a/common/src/main/java/org/terracotta/angela/common/tcconfig/TerracottaServer.java
+++ b/common/src/main/java/org/terracotta/angela/common/tcconfig/TerracottaServer.java
@@ -16,6 +16,7 @@
 package org.terracotta.angela.common.tcconfig;
 
 import org.terracotta.angela.common.util.HostPort;
+import org.terracotta.angela.common.util.IpUtils;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -69,6 +70,10 @@ public class TerracottaServer {
 
   public static TerracottaServer server(String symbolicName, String hostName) {
     return new TerracottaServer(symbolicName, hostName);
+  }
+
+  public static TerracottaServer server(String symbolicName) {
+    return new TerracottaServer(symbolicName, IpUtils.getHostName());
   }
 
   public TerracottaServer tsaPort(int tsaPort) {

--- a/common/src/main/java/org/terracotta/angela/common/tcconfig/holders/TcConfigHolder.java
+++ b/common/src/main/java/org/terracotta/angela/common/tcconfig/holders/TcConfigHolder.java
@@ -22,6 +22,7 @@ import org.terracotta.angela.common.net.PortAllocator;
 import org.terracotta.angela.common.tcconfig.ServerSymbolicName;
 import org.terracotta.angela.common.tcconfig.TerracottaServer;
 import org.terracotta.angela.common.tcconfig.TsaStripeConfig;
+import org.terracotta.angela.common.util.IpUtils;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -128,7 +129,7 @@ public abstract class TcConfigHolder {
         Node hostNode = (Node) xPath.evaluate("@host", server, XPathConstants.NODE);
         String hostname =
             hostNode == null || hostNode.getTextContent().equals("%i") || hostNode.getTextContent()
-                .equals("%h") ? "localhost" : hostNode.getTextContent();
+                .equals("%h") ? IpUtils.getHostName() : hostNode.getTextContent();
 
         Node nameNode = (Node) xPath.evaluate("@name", server, XPathConstants.NODE);
 

--- a/common/src/main/java/org/terracotta/angela/common/topology/TmsConfig.java
+++ b/common/src/main/java/org/terracotta/angela/common/topology/TmsConfig.java
@@ -15,8 +15,6 @@
  */
 package org.terracotta.angela.common.topology;
 
-import org.terracotta.angela.common.util.IpUtils;
-
 public class TmsConfig {
 
   private final String hostname;
@@ -29,10 +27,6 @@ public class TmsConfig {
 
   public String getHostname() {
     return hostname;
-  }
-
-  public String getIp() {
-    return IpUtils.getHostAddress(hostname);
   }
 
   public int getTmsPort() {

--- a/common/src/main/java/org/terracotta/angela/common/util/IgniteCommonHelper.java
+++ b/common/src/main/java/org/terracotta/angela/common/util/IgniteCommonHelper.java
@@ -16,11 +16,8 @@
 package org.terracotta.angela.common.util;
 
 import org.apache.ignite.Ignite;
-import org.apache.ignite.cluster.ClusterGroup;
 import org.apache.ignite.cluster.ClusterNode;
 import org.apache.ignite.configuration.CollectionConfiguration;
-import org.apache.ignite.lang.IgniteCallable;
-import org.apache.ignite.lang.IgniteFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terracotta.angela.common.topology.InstanceId;
@@ -28,7 +25,6 @@ import org.terracotta.angela.common.topology.InstanceId;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 public class IgniteCommonHelper {
@@ -36,15 +32,6 @@ public class IgniteCommonHelper {
 
   public static BlockingQueue<Object> fileTransferQueue(Ignite ignite, InstanceId instanceId) {
     return ignite.queue(instanceId + "@file-transfer-queue", 100, new CollectionConfiguration());
-  }
-
-  public static void checkForDuplicateAgent(Ignite ignite, String nodeName) {
-    ClusterGroup location = ignite.cluster().forAttribute("nodename", nodeName);
-    IgniteFuture<Collection<Object>> future = ignite.compute(location).broadcastAsync((IgniteCallable<Object>) () -> 0);
-    Collection<Object> results = future.get(60, TimeUnit.SECONDS);
-    if (results.size() != 1) {
-      throw new IllegalStateException("Node with name [" + nodeName + "] already exists on the network, refusing to duplicate it.");
-    }
   }
 
   public static void displayCluster(Ignite ignite) {

--- a/common/src/main/java/org/terracotta/angela/common/util/IpUtils.java
+++ b/common/src/main/java/org/terracotta/angela/common/util/IpUtils.java
@@ -23,6 +23,7 @@ public class IpUtils {
 
   private static final String LOCAL_HOSTNAME;
 
+  // caches costly resolutions
   static {
     try {
       LOCAL_HOSTNAME = InetAddress.getLocalHost().getHostName();
@@ -31,18 +32,22 @@ public class IpUtils {
     }
   }
 
-  public static boolean isLocal(String targetServerName) {
-    if (targetServerName.equals(LOCAL_HOSTNAME)) {
-      return true;
+  /**
+   * Try to determine (but not accurately) if a given name matches a local address.
+   * A local address is a local IP or local hostname.
+   * <p>
+   * This "name" can be any Angela generated names (i.e. in case of client arrays instanceId or symbolic names),
+   * we do not use "getByName()" to avoid any dns resolution
+   */
+  public static boolean isLocal(String name) {
+    switch (name) {
+      case "localhost":
+      case "127.0.0.1":
+      case " ::1":
+        return true;
+      default:
+        return LOCAL_HOSTNAME.equals(name) || name.startsWith("169.254.") || name.startsWith("fe80:");
     }
-
-    InetAddress address;
-    try {
-      address = InetAddress.getByName(targetServerName);
-    } catch (UnknownHostException e) {
-      throw new RuntimeException(e);
-    }
-    return address.isLoopbackAddress() || address.isLinkLocalAddress();
   }
 
   public static boolean areAllLocal(Collection<String> targetServerNames) {
@@ -56,13 +61,5 @@ public class IpUtils {
 
   public static String getHostName() {
     return LOCAL_HOSTNAME;
-  }
-
-  public static String getHostAddress(String host) {
-    try {
-      return InetAddress.getByName(host).getHostAddress();
-    } catch (UnknownHostException e) {
-      throw new RuntimeException(e);
-    }
   }
 }

--- a/common/src/main/java/org/terracotta/angela/common/util/IpUtils.java
+++ b/common/src/main/java/org/terracotta/angela/common/util/IpUtils.java
@@ -54,15 +54,6 @@ public class IpUtils {
     return true;
   }
 
-  public static boolean isAnyLocal(Collection<String> targetServerNames) {
-    for (String targetServerName : targetServerNames) {
-      if (isLocal(targetServerName)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
   public static String getHostName() {
     return LOCAL_HOSTNAME;
   }

--- a/docs/src/main/java/GettingStarted.java
+++ b/docs/src/main/java/GettingStarted.java
@@ -121,28 +121,28 @@ public class GettingStarted {
                     distribution(version(EHCACHE_VERSION), KIT, TERRACOTTA_OS),
                     dynamicCluster( // <1>
                         stripe(
-                            server("server-1", "localhost")
+                            server("server-1")
                                 .tsaPort(9410)
                                 .tsaGroupPort(9411)
                                 .configRepo("terracotta1/repository")
                                 .logs("terracotta1/logs")
                                 .metaData("terracotta1/metadata")
                                 .failoverPriority("availability"),
-                            server("server-2", "localhost")
+                            server("server-2")
                                 .tsaPort(9510)
                                 .tsaGroupPort(9511)
                                 .configRepo("terracotta2/repository")
                                 .logs("terracotta2/logs")
                                 .metaData("terracotta2/metadata")
                                 .failoverPriority("availability"))))))
-        .configTool(context -> context.configTool(configTool("configTool", "localhost")));
+        .configTool(context -> context.configTool(configTool("configTool")));
     try (ClusterFactory factory = angelaOrchestratorRule.newClusterFactory("DynamicClusterTest::testSingleStripeFormation", configContext)) {
       Tsa tsa = factory.tsa();
       tsa.startAll(); // <2>
       ConfigTool configTool = factory.configTool();
       configTool.attachAll(); // <3>
 
-      configTool.attachStripe(server("server-3", "localhost") // <4>
+      configTool.attachStripe(server("server-3") // <4>
           .tsaPort(9610)
           .tsaGroupPort(9611)
           .configRepo("terracotta3/repository")
@@ -166,7 +166,7 @@ public class GettingStarted {
         .clientArray(clientArray -> clientArray // <1>
             .clientArrayTopology(new ClientArrayTopology( // <2>
                 distribution(version(EHCACHE_OS_VERSION), PackageType.KIT, LicenseType.TERRACOTTA_OS), // <3>
-                newClientArrayConfig().host("localhost-1", "localhost").host("localhost-2", "localhost")) // <4>
+                newClientArrayConfig().named("localhost-1").named("localhost-2")) // <4>
             )
         );
     ClusterFactory factory = angelaOrchestratorRule.newClusterFactory("GettingStarted::runClient", configContext);

--- a/integration-test/src/test/java/org/terracotta/angela/AngelaRuleIT.java
+++ b/integration-test/src/test/java/org/terracotta/angela/AngelaRuleIT.java
@@ -48,19 +48,19 @@ public class AngelaRuleIT {
   AngelaRule angelaRule = new AngelaRule(
       () -> angelaOrchestratorRule.getAngelaOrchestrator(),
       customConfigurationContext()
-          .configTool(context -> context.configTool(configTool("config-tool", "localhost")).distribution(DISTRIBUTION))
+          .configTool(context -> context.configTool(configTool("config-tool")).distribution(DISTRIBUTION))
           .tsa(tsa -> tsa
               .topology(
                   new Topology(
                       DISTRIBUTION,
                       dynamicCluster(
                           stripe(
-                              server("server-1", "localhost")
+                              server("server-1")
                                   .configRepo("terracotta1/repository")
                                   .logs("terracotta1/logs")
                                   .metaData("terracotta1/metadata")
                                   .failoverPriority("availability"),
-                              server("server-2", "localhost")
+                              server("server-2")
                                   .configRepo("terracotta2/repository")
                                   .logs("terracotta2/logs")
                                   .metaData("terracotta2/metadata")

--- a/integration-test/src/test/java/org/terracotta/angela/BrowseIT.java
+++ b/integration-test/src/test/java/org/terracotta/angela/BrowseIT.java
@@ -63,7 +63,7 @@ public class BrowseIT {
   public void testClient() throws Exception {
     ConfigurationContext configContext = CustomConfigurationContext.customConfigurationContext()
         .clientArray(clientArray -> clientArray.license(TERRACOTTA_OS.defaultLicense())
-            .clientArrayTopology(new ClientArrayTopology(distribution(version(EHCACHE_VERSION), PackageType.KIT, TERRACOTTA_OS), newClientArrayConfig().host("localhost")))
+            .clientArrayTopology(new ClientArrayTopology(distribution(version(EHCACHE_VERSION), PackageType.KIT, TERRACOTTA_OS), newClientArrayConfig().named("localhost")))
         );
     try (ClusterFactory factory = angelaOrchestratorRule.newClusterFactory("BrowseTest::testClient", configContext)) {
       ClientArray clientArray = factory.clientArray(0);
@@ -123,7 +123,7 @@ public class BrowseIT {
   public void testNonExistentFolder() throws Exception {
     ConfigurationContext configContext = CustomConfigurationContext.customConfigurationContext()
         .clientArray(clientArray -> clientArray.license(TERRACOTTA_OS.defaultLicense())
-            .clientArrayTopology(new ClientArrayTopology(distribution(version(EHCACHE_VERSION), PackageType.KIT, TERRACOTTA_OS), newClientArrayConfig().host("localhost")))
+            .clientArrayTopology(new ClientArrayTopology(distribution(version(EHCACHE_VERSION), PackageType.KIT, TERRACOTTA_OS), newClientArrayConfig().named("localhost")))
         );
 
     try (ClusterFactory factory = angelaOrchestratorRule.newClusterFactory("BrowseTest::testNonExistentFolder", configContext)) {
@@ -142,7 +142,7 @@ public class BrowseIT {
   public void testUpload() throws Exception {
     ConfigurationContext configContext = CustomConfigurationContext.customConfigurationContext()
         .clientArray(clientArray -> clientArray.license(TERRACOTTA_OS.defaultLicense())
-            .clientArrayTopology(new ClientArrayTopology(distribution(version(EHCACHE_VERSION), PackageType.KIT, TERRACOTTA_OS), newClientArrayConfig().host("localhost")))
+            .clientArrayTopology(new ClientArrayTopology(distribution(version(EHCACHE_VERSION), PackageType.KIT, TERRACOTTA_OS), newClientArrayConfig().named("localhost")))
         );
 
     try (ClusterFactory factory = angelaOrchestratorRule.newClusterFactory("BrowseTest::testUpload", configContext)) {

--- a/integration-test/src/test/java/org/terracotta/angela/ConfigToolIT.java
+++ b/integration-test/src/test/java/org/terracotta/angela/ConfigToolIT.java
@@ -65,7 +65,7 @@ public class ConfigToolIT {
 
   @Test
   public void testFailingConfigToolCommand() throws Exception {
-    TerracottaServer server = server("server-1", "localhost")
+    TerracottaServer server = server("server-1")
         .tsaPort(ports[0])
         .tsaGroupPort(ports[1])
         .configRepo("terracotta1/repository")
@@ -75,7 +75,7 @@ public class ConfigToolIT {
     Distribution distribution = distribution(version("3.9-SNAPSHOT"), KIT, TERRACOTTA_OS);
     ConfigurationContext configContext = customConfigurationContext()
         .tsa(context -> context.topology(new Topology(distribution, dynamicCluster(stripe(server)))))
-        .configTool(context -> context.configTool(configTool("config-tool", "localhost")).distribution(distribution));
+        .configTool(context -> context.configTool(configTool("config-tool")).distribution(distribution));
 
     try (ClusterFactory factory = angelaOrchestratorRule.newClusterFactory("ConfigToolTest::testFailingClusterToolCommand", configContext)) {
       Tsa tsa = factory.tsa();
@@ -89,7 +89,7 @@ public class ConfigToolIT {
 
   @Test
   public void testValidConfigToolCommand() throws Exception {
-    TerracottaServer server = server("server-1", "localhost")
+    TerracottaServer server = server("server-1")
         .tsaPort(ports[0])
         .tsaGroupPort(ports[1])
         .configRepo("terracotta1/repository")
@@ -99,7 +99,7 @@ public class ConfigToolIT {
     Distribution distribution = distribution(version("3.9-SNAPSHOT"), KIT, TERRACOTTA_OS);
     ConfigurationContext configContext = customConfigurationContext()
         .tsa(context -> context.topology(new Topology(distribution, dynamicCluster(stripe(server)))))
-        .configTool(context -> context.configTool(configTool("config-tool", "localhost")).distribution(distribution));
+        .configTool(context -> context.configTool(configTool("config-tool")).distribution(distribution));
 
     try (ClusterFactory factory = angelaOrchestratorRule.newClusterFactory("ConfigToolTest::testValidConfigToolCommand", configContext)) {
       Tsa tsa = factory.tsa();

--- a/integration-test/src/test/java/org/terracotta/angela/DynamicClusterIT.java
+++ b/integration-test/src/test/java/org/terracotta/angela/DynamicClusterIT.java
@@ -69,14 +69,14 @@ public class DynamicClusterIT {
                     DISTRIBUTION,
                     dynamicCluster(
                         stripe(
-                            server("server-1", "localhost")
+                            server("server-1")
                                 .tsaPort(ports[0])
                                 .tsaGroupPort(ports[1])
                                 .configRepo("terracotta1/repository")
                                 .logs("terracotta1/logs")
                                 .metaData("terracotta1/metadata")
                                 .failoverPriority("availability"),
-                            server("server-2", "localhost")
+                            server("server-2")
                                 .tsaPort(ports[2])
                                 .tsaGroupPort(ports[3])
                                 .configRepo("terracotta2/repository")
@@ -108,7 +108,7 @@ public class DynamicClusterIT {
                     DISTRIBUTION,
                     dynamicCluster(
                         stripe(
-                            server("server-1", "localhost")
+                            server("server-1")
                                 .tsaPort(ports[0])
                                 .tsaGroupPort(ports[1])
                                 .configRepo("terracotta1/repository")
@@ -119,7 +119,7 @@ public class DynamicClusterIT {
                     )
                 )
             )
-        ).configTool(context -> context.configTool(configTool("configTool", "localhost")).distribution(DISTRIBUTION));
+        ).configTool(context -> context.configTool(configTool("configTool")).distribution(DISTRIBUTION));
 
     try (ClusterFactory factory = angelaOrchestratorRule.newClusterFactory("DynamicClusterTest::testDynamicNodeAttachToSingleNodeStripe", configContext)) {
       Tsa tsa = factory.tsa();
@@ -128,7 +128,7 @@ public class DynamicClusterIT {
       waitFor(() -> tsa.getTsaConfigurationContext().getTopology().getStripes().size(), is(1));
       waitFor(() -> tsa.getTsaConfigurationContext().getTopology().getStripes().get(0).size(), is(1));
 
-      factory.configTool().attachNode(0, server("server-2", "localhost")
+      factory.configTool().attachNode(0, server("server-2")
           .tsaPort(ports[2])
           .tsaGroupPort(ports[3])
           .configRepo("terracotta2/repository")
@@ -150,14 +150,14 @@ public class DynamicClusterIT {
                     DISTRIBUTION,
                     dynamicCluster(
                         stripe(
-                            server("server-1", "localhost")
+                            server("server-1")
                                 .tsaPort(ports[0])
                                 .tsaGroupPort(ports[1])
                                 .configRepo("terracotta1/repository")
                                 .logs("terracotta1/logs")
                                 .metaData("terracotta1/metadata")
                                 .failoverPriority("availability"),
-                            server("server-2", "localhost")
+                            server("server-2")
                                 .tsaPort(ports[2])
                                 .tsaGroupPort(ports[3])
                                 .configRepo("terracotta2/repository")
@@ -168,7 +168,7 @@ public class DynamicClusterIT {
                     )
                 )
             )
-        ).configTool(context -> context.configTool(configTool("configTool", "localhost")).distribution(DISTRIBUTION));
+        ).configTool(context -> context.configTool(configTool("configTool")).distribution(DISTRIBUTION));
 
     try (ClusterFactory factory = angelaOrchestratorRule.newClusterFactory("DynamicClusterTest::testDynamicNodeAttachToMultiNodeStripe", configContext)) {
       Tsa tsa = factory.tsa();
@@ -177,7 +177,7 @@ public class DynamicClusterIT {
       waitFor(() -> tsa.getTsaConfigurationContext().getTopology().getStripes().size(), is(1));
       waitFor(() -> tsa.getTsaConfigurationContext().getTopology().getStripes().get(0).size(), is(2));
 
-      factory.configTool().attachNode(0, server("server-3", "localhost")
+      factory.configTool().attachNode(0, server("server-3")
           .tsaPort(ports[4])
           .tsaGroupPort(ports[5])
           .configRepo("terracotta3/repository")
@@ -199,7 +199,7 @@ public class DynamicClusterIT {
                     DISTRIBUTION,
                     dynamicCluster(
                         stripe(
-                            server("server-1", "localhost")
+                            server("server-1")
                                 .tsaPort(ports[0])
                                 .tsaGroupPort(ports[1])
                                 .configRepo("terracotta1/repository")
@@ -210,7 +210,7 @@ public class DynamicClusterIT {
                     )
                 )
             )
-        ).configTool(context -> context.configTool(configTool("configTool", "localhost")).distribution(DISTRIBUTION));
+        ).configTool(context -> context.configTool(configTool("configTool")).distribution(DISTRIBUTION));
 
     try (ClusterFactory factory = angelaOrchestratorRule.newClusterFactory("DynamicClusterTest::testDynamicStripeAttachToSingleStripeCluster", configContext)) {
       Tsa tsa = factory.tsa();
@@ -219,7 +219,7 @@ public class DynamicClusterIT {
       waitFor(() -> tsa.getTsaConfigurationContext().getTopology().getStripes().size(), is(1));
       waitFor(() -> tsa.getTsaConfigurationContext().getTopology().getStripes().get(0).size(), is(1));
 
-      factory.configTool().attachStripe(server("server-2", "localhost")
+      factory.configTool().attachStripe(server("server-2")
           .tsaPort(ports[2])
           .tsaGroupPort(ports[3])
           .configRepo("terracotta2/repository")
@@ -242,7 +242,7 @@ public class DynamicClusterIT {
                     DISTRIBUTION,
                     dynamicCluster(
                         stripe(
-                            server("server-1", "localhost")
+                            server("server-1")
                                 .tsaPort(ports[0])
                                 .tsaGroupPort(ports[1])
                                 .configRepo("terracotta1/repository")
@@ -251,7 +251,7 @@ public class DynamicClusterIT {
                                 .failoverPriority("availability")
                         ),
                         stripe(
-                            server("server-2", "localhost")
+                            server("server-2")
                                 .tsaPort(ports[2])
                                 .tsaGroupPort(ports[3])
                                 .configRepo("terracotta2/repository")
@@ -262,7 +262,7 @@ public class DynamicClusterIT {
                     )
                 )
             )
-        ).configTool(context -> context.configTool(configTool("configTool", "localhost")).distribution(DISTRIBUTION));
+        ).configTool(context -> context.configTool(configTool("configTool")).distribution(DISTRIBUTION));
 
     try (ClusterFactory factory = angelaOrchestratorRule.newClusterFactory("DynamicClusterTest::testDynamicStripeAttachToMultiStripeCluster", configContext)) {
       Tsa tsa = factory.tsa();
@@ -272,7 +272,7 @@ public class DynamicClusterIT {
       waitFor(() -> tsa.getTsaConfigurationContext().getTopology().getStripes().get(0).size(), is(1));
       waitFor(() -> tsa.getTsaConfigurationContext().getTopology().getStripes().get(1).size(), is(1));
 
-      factory.configTool().attachStripe(server("server-3", "localhost")
+      factory.configTool().attachStripe(server("server-3")
           .tsaPort(ports[4])
           .tsaGroupPort(ports[5])
           .configRepo("terracotta3/repository")
@@ -295,14 +295,14 @@ public class DynamicClusterIT {
                     DISTRIBUTION,
                     dynamicCluster(
                         stripe(
-                            server("server-1", "localhost")
+                            server("server-1")
                                 .tsaPort(ports[0])
                                 .tsaGroupPort(ports[1])
                                 .configRepo("terracotta1/repository")
                                 .logs("terracotta1/logs")
                                 .metaData("terracotta1/metadata")
                                 .failoverPriority("availability"),
-                            server("server-2", "localhost")
+                            server("server-2")
                                 .tsaPort(ports[2])
                                 .tsaGroupPort(ports[3])
                                 .configRepo("terracotta2/repository")
@@ -313,7 +313,7 @@ public class DynamicClusterIT {
                     )
                 )
             )
-        ).configTool(context -> context.configTool(configTool("configTool", "localhost")).distribution(DISTRIBUTION));
+        ).configTool(context -> context.configTool(configTool("configTool")).distribution(DISTRIBUTION));
 
 
     try (ClusterFactory factory = angelaOrchestratorRule.newClusterFactory("DynamicClusterTest::testSingleStripeFormation", configContext)) {
@@ -335,14 +335,14 @@ public class DynamicClusterIT {
                     DISTRIBUTION,
                     dynamicCluster(
                         stripe(
-                            server("server-1", "localhost")
+                            server("server-1")
                                 .tsaPort(ports[0])
                                 .tsaGroupPort(ports[1])
                                 .configRepo("terracotta1/repository")
                                 .logs("terracotta1/logs")
                                 .metaData("terracotta1/metadata")
                                 .failoverPriority("availability"),
-                            server("server-2", "localhost")
+                            server("server-2")
                                 .tsaPort(ports[2])
                                 .tsaGroupPort(ports[3])
                                 .configRepo("terracotta2/repository")
@@ -351,14 +351,14 @@ public class DynamicClusterIT {
                                 .failoverPriority("availability")
                         ),
                         stripe(
-                            server("server-3", "localhost")
+                            server("server-3")
                                 .tsaPort(ports[4])
                                 .tsaGroupPort(ports[5])
                                 .configRepo("terracotta3/repository")
                                 .logs("terracotta3/logs")
                                 .metaData("terracotta3/metadata")
                                 .failoverPriority("availability"),
-                            server("server-4", "localhost")
+                            server("server-4")
                                 .tsaPort(ports[6])
                                 .tsaGroupPort(ports[7])
                                 .configRepo("terracotta4/repository")
@@ -369,7 +369,7 @@ public class DynamicClusterIT {
                     )
                 )
             )
-        ).configTool(context -> context.configTool(configTool("configTool", "localhost")).distribution(DISTRIBUTION));
+        ).configTool(context -> context.configTool(configTool("configTool")).distribution(DISTRIBUTION));
 
     try (ClusterFactory factory = angelaOrchestratorRule.newClusterFactory("DynamicClusterTest::testMultiStripeFormation", configContext)) {
       Tsa tsa = factory.tsa();
@@ -391,7 +391,7 @@ public class DynamicClusterIT {
                     DISTRIBUTION,
                     dynamicCluster(
                         stripe(
-                            server("server-1", "localhost")
+                            server("server-1")
                                 .tsaPort(ports[0])
                                 .tsaGroupPort(ports[1])
                                 .configRepo("terracotta1/repository")
@@ -400,7 +400,7 @@ public class DynamicClusterIT {
                                 .failoverPriority("availability")
                         ),
                         stripe(
-                            server("server-2", "localhost")
+                            server("server-2")
                                 .tsaPort(ports[2])
                                 .tsaGroupPort(ports[3])
                                 .configRepo("terracotta2/repository")
@@ -411,7 +411,7 @@ public class DynamicClusterIT {
                     )
                 )
             )
-        ).configTool(context -> context.configTool(configTool("configTool", "localhost")).distribution(DISTRIBUTION));
+        ).configTool(context -> context.configTool(configTool("configTool")).distribution(DISTRIBUTION));
 
     try (ClusterFactory factory = angelaOrchestratorRule.newClusterFactory("DynamicClusterTest::testDynamicStripeDetach", configContext)) {
       Tsa tsa = factory.tsa();
@@ -443,14 +443,14 @@ public class DynamicClusterIT {
                     DISTRIBUTION,
                     dynamicCluster(
                         stripe(
-                            server("server-1", "localhost")
+                            server("server-1")
                                 .tsaPort(ports[0])
                                 .tsaGroupPort(ports[1])
                                 .configRepo("terracotta1/repository")
                                 .logs("terracotta1/logs")
                                 .metaData("terracotta1/metadata")
                                 .failoverPriority("availability"),
-                            server("server-2", "localhost")
+                            server("server-2")
                                 .tsaPort(ports[2])
                                 .tsaGroupPort(ports[3])
                                 .configRepo("terracotta2/repository")
@@ -462,7 +462,7 @@ public class DynamicClusterIT {
                 )
             )
         ).configTool(context -> context
-            .configTool(configTool("configTool", "localhost"))
+            .configTool(configTool("configTool"))
             .distribution(DISTRIBUTION));
 
     try (ClusterFactory factory = angelaOrchestratorRule.newClusterFactory("DynamicClusterTest::testNodeActivation", configContext)) {
@@ -487,7 +487,7 @@ public class DynamicClusterIT {
                     DISTRIBUTION,
                     dynamicCluster(
                         stripe(
-                            server("node-1", "localhost")
+                            server("node-1")
                                 .bindAddress("::")
                                 .groupBindAddress("::")
                                 .tsaPort(ports[0])
@@ -496,7 +496,7 @@ public class DynamicClusterIT {
                                 .configRepo("terracotta1/repo")
                                 .metaData("terracotta1/metadata")
                                 .failoverPriority("availability"),
-                            server("node-2", "localhost")
+                            server("node-2")
                                 .bindAddress("::")
                                 .groupBindAddress("::")
                                 .tsaPort(ports[2])
@@ -509,7 +509,7 @@ public class DynamicClusterIT {
                     )
                 )
             )
-        ).configTool(context -> context.configTool(configTool("configTool", "localhost")).distribution(DISTRIBUTION));
+        ).configTool(context -> context.configTool(configTool("configTool")).distribution(DISTRIBUTION));
 
     try (ClusterFactory factory = angelaOrchestratorRule.newClusterFactory("DynamicClusterTest::testIpv6", configurationContext)) {
       Tsa tsa = factory.tsa();

--- a/integration-test/src/test/java/org/terracotta/angela/EhcacheIT.java
+++ b/integration-test/src/test/java/org/terracotta/angela/EhcacheIT.java
@@ -101,7 +101,7 @@ public class EhcacheIT {
             clientArray -> clientArray.clientArrayTopology(
                 new ClientArrayTopology(
                     distribution(version(EHCACHE_VERSION), PackageType.KIT, LicenseType.TERRACOTTA_OS),
-                    newClientArrayConfig().host("localhost")
+                    newClientArrayConfig().named("localhost")
                 )
             )
         );

--- a/integration-test/src/test/java/org/terracotta/angela/VoterIT.java
+++ b/integration-test/src/test/java/org/terracotta/angela/VoterIT.java
@@ -30,7 +30,7 @@ import java.time.Duration;
 import static org.awaitility.Awaitility.await;
 import static org.terracotta.angela.client.config.custom.CustomConfigurationContext.customConfigurationContext;
 import static org.terracotta.angela.common.TerracottaConfigTool.configTool;
-import static org.terracotta.angela.common.TerracottaVoter.voter;
+import static org.terracotta.angela.common.TerracottaVoter.localVoter;
 import static org.terracotta.angela.common.TerracottaVoterState.CONNECTED_TO_ACTIVE;
 import static org.terracotta.angela.common.distribution.Distribution.distribution;
 import static org.terracotta.angela.common.dynamic_cluster.Stripe.stripe;
@@ -58,22 +58,22 @@ public class VoterIT {
                     distribution,
                     dynamicCluster(
                         stripe(
-                            server("server-1", "localhost")
+                            server("server-1")
                                 .tsaPort(ports[0])
                                 .tsaGroupPort(ports[1])
                                 .configRepo("terracotta1/repository")
                                 .logs("terracotta1/logs")
                                 .metaData("terracotta1/metadata")
                                 .failoverPriority("consistency:1"),
-                            server("server-2", "localhost")
+                            server("server-2")
                                 .tsaPort(ports[2])
                                 .tsaGroupPort(ports[3])
                                 .configRepo("terracotta2/repository")
                                 .logs("terracotta2/logs")
                                 .metaData("terracotta2/metadata")
                                 .failoverPriority("consistency:1"))))))
-        .voter(voter -> voter.distribution(distribution).addVoter(voter("voter", "localhost", "localhost:" + ports[0], "localhost:" + ports[2])))
-        .configTool(context -> context.distribution(distribution).configTool(configTool("config-tool", "localhost")));
+        .voter(voter -> voter.distribution(distribution).addVoter(localVoter("voter", "localhost:" + ports[0], "localhost:" + ports[2])))
+        .configTool(context -> context.distribution(distribution).configTool(configTool("config-tool")));
 
     try (ClusterFactory factory = angelaOrchestratorRule.newClusterFactory("VoterTest::testVoterStartup", configContext)) {
       factory.tsa().startAll();


### PR DESCRIPTION
…er support remote communication and avoid spawning a second ignite process locally through SSH when the passed hostname would point to the same machine as localhost.

**Explanation of this PR:**

There is a bug caused by the fact that ignite nodes were not discovering themselves remotely.

This is partly due to how local addresses are treated.

In DC we need to have tests using both localhost and the machine hostname.

But when specifying other thing than localhost, Angela was treating any hostname being remote, and consequently was trying to install through SSH an agent on the same machine we are.

This was fixed in IPUtil.

The problem is that this fix was then preventing using Angela normally with SSH in the case machine hostname is specified with localhost because the cluster was not finding any ignite node with the machine name.

Besides, the hostname is used for node discovery so in the case of remote nodes, no localhost can be used.

**This PR does the followng:**

1) It makes the "hostname" parameter optional in the config
2) if not provided, by default, the hostname will be the machine hostname - no localhost anymore
3) treats localhost (as sourced from config files for example) as being the same as the machine name when computing the ignite node to communicate with
4) Improves the IPUtils class to cover most of 90% use cases when detecting local addresses and avoid any unecessary DNS lookups

**TESTING:**

- [X] angela tests pass in this project
- [x] angela tests pass in tc-platfom
- [ ] angela tests pass in angela-ee (most of, since all cannot be ran locally)
- [ ] angela tests pass in EE
- [x] @jko314 has verified that this PR also fixes the bug he saw concerning empty Ignite groups when using Angela with ssh