### PR TITLE
initialize necessary fields in AgentOrchestrator constructor

### DIFF
--- a/client-internal/src/main/java/org/terracotta/angela/client/AngelaOrchestrator.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/AngelaOrchestrator.java
@@ -129,7 +129,7 @@ public class AngelaOrchestrator implements Closeable {
   }
 
   public static AngelaOrchestratorBuilder builder() {
-    return new AngelaOrchestratorBuilder().igniteRemote();
+    return new AngelaOrchestratorBuilder();
   }
 
   public static class AngelaOrchestratorBuilder {
@@ -139,6 +139,10 @@ public class AngelaOrchestrator implements Closeable {
     private Supplier<Agent> agentBuilder;
     private Function<Agent, Executor> executorBuilder;
     private String mode; // just for toString()
+
+    private AngelaOrchestratorBuilder() {
+      igniteRemote();
+    }
 
     /**
      * @deprecated Use {@link #igniteFree()} instead


### PR DESCRIPTION
Fix the following issue:
The default constructor of the AgentOrchestratorBuilder didn't initialize the agentBuilder, the executorBuilder and the mode fields, so doing :

AngelaOrchestrator angelaOrchestrator = new AngelaOrchestratorBuilder().build() 

would result in a NPE
(This fix is not worth a new release but would be good to be included n the future one)