### PR TITLE
auto-create tms audit log dir under working dir if does not exist + Fixes a couple of TMS support issues

### DIFF
--- a/common/src/main/java/org/terracotta/angela/common/distribution/Distribution102Controller.java
+++ b/common/src/main/java/org/terracotta/angela/common/distribution/Distribution102Controller.java
@@ -35,6 +35,7 @@ import org.terracotta.angela.common.tcconfig.SecurityRootDirectory;
 import org.terracotta.angela.common.tcconfig.ServerSymbolicName;
 import org.terracotta.angela.common.tcconfig.TcConfig;
 import org.terracotta.angela.common.tcconfig.TerracottaServer;
+import org.terracotta.angela.common.tms.security.config.TmsServerSecurityConfig;
 import org.terracotta.angela.common.topology.PackageType;
 import org.terracotta.angela.common.topology.Topology;
 import org.terracotta.angela.common.util.ExternalLoggers;
@@ -288,6 +289,16 @@ public class Distribution102Controller extends DistributionController {
   @Override
   public String terracottaInstallationRoot() {
     return "TerracottaDB";
+  }
+
+  @Override
+  public void prepareTMS(File kitDir, File workingDir, TmsServerSecurityConfig tmsServerSecurityConfig) {
+    if (!AngelaProperties.KIT_COPY.getBooleanValue()) {
+      throw new IllegalStateException(AngelaProperties.KIT_COPY.getPropertyName() + "=true is required with the kit version used");
+    }
+    File tmcPropertiesInput = new File(kitDir, "tools/management/conf/tmc.properties");
+    File tmcPropertiesOutput = new File(workingDir, "tools/management/conf/tmc.properties");
+    prepareTMS(tmcPropertiesInput, tmcPropertiesOutput, tmsServerSecurityConfig, workingDir);
   }
 
   private List<String> createClusterToolCommand(File installLocation, File workingDir, SecurityRootDirectory securityDir, String[] arguments) {

--- a/common/src/main/java/org/terracotta/angela/common/distribution/Distribution43Controller.java
+++ b/common/src/main/java/org/terracotta/angela/common/distribution/Distribution43Controller.java
@@ -32,6 +32,7 @@ import org.terracotta.angela.common.tcconfig.SecurityRootDirectory;
 import org.terracotta.angela.common.tcconfig.ServerSymbolicName;
 import org.terracotta.angela.common.tcconfig.TcConfig;
 import org.terracotta.angela.common.tcconfig.TerracottaServer;
+import org.terracotta.angela.common.tms.security.config.TmsServerSecurityConfig;
 import org.terracotta.angela.common.topology.Topology;
 import org.terracotta.angela.common.topology.Version;
 import org.terracotta.angela.common.util.ExternalLoggers;
@@ -375,5 +376,9 @@ public class Distribution43Controller extends DistributionController {
   @Override
   public String terracottaInstallationRoot() {
     return "Terracotta";
+  }
+
+  @Override
+  public void prepareTMS(File kitDir, File workingDir, TmsServerSecurityConfig tmsServerSecurityConfig) {
   }
 }


### PR DESCRIPTION
Fixing Angela TMS support:

- Added support for port mapper when starting TMS, even remotely (port is forwarded back to the test)
- 10.2 Distribution102Controller requires kit copy to use TMS because the config file is updated within the kit
- 10.7 Distribution102Controller is able to use copy mode or not: all TMS config files and data are put in the angela working dir, the kit dir is left untouched and the TMS home is set to the angela work dir
- auto-create tms audit log dir under working dir if does not exist

These changes have been tested in angela-ee with 10.2 distribution class and TcDbTests project with the 10.5 dist class.