### PR TITLE
Activity tracker + TMS fix

### DIFF
--- a/agent-lib/src/main/java/org/terracotta/angela/agent/AgentController.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/agent/AgentController.java
@@ -62,6 +62,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -404,9 +405,9 @@ public class AgentController {
     }
   }
 
-  public void createTsa(InstanceId instanceId, TerracottaServer terracottaServer, TerracottaCommandLineEnvironment tcEnv, Map<String, String> envOverrides, List<String> startUpArgs) {
+  public void createTsa(InstanceId instanceId, TerracottaServer terracottaServer, TerracottaCommandLineEnvironment tcEnv, Map<String, String> envOverrides, List<String> startUpArgs, Duration inactivityKillerDelay) {
     TerracottaServerInstance serverInstance = tsaInstalls.get(instanceId).getTerracottaServerInstance(terracottaServer);
-    serverInstance.create(tcEnv, envOverrides, startUpArgs);
+    serverInstance.create(tcEnv, envOverrides, startUpArgs, inactivityKillerDelay);
   }
 
   public void stopTsa(InstanceId instanceId, TerracottaServer terracottaServer) {

--- a/agent-lib/src/main/java/org/terracotta/angela/agent/AgentController.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/agent/AgentController.java
@@ -220,10 +220,7 @@ public class AgentController {
         return false;
       }
 
-      // DO NOT ALTER THE KIT CONTENT IF kitInstallationPath IS USED
-      if (kitInstallationPath == null) {
-        distribution.createDistributionController().prepareTMS(dirs.get().kitDir, dirs.get().workingDir, tmsServerSecurityConfig);
-      }
+      distribution.createDistributionController().prepareTMS(dirs.get().kitDir, dirs.get().workingDir, tmsServerSecurityConfig);
 
       tmsInstalls.put(instanceId, new TmsInstall(distribution, dirs.get().kitDir, dirs.get().workingDir, tcEnv));
       return true;

--- a/client-internal/src/main/java/org/terracotta/angela/client/Tsa.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/Tsa.java
@@ -44,6 +44,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -236,7 +237,8 @@ public class Tsa implements AutoCloseable {
         logger.info("Creating TSA: {} on: {}", instanceId, agentID);
         String whatFor = SERVER_START_PREFIX + terracottaServer.getServerSymbolicName().getSymbolicName();
         TerracottaCommandLineEnvironment cliEnv = tsaConfigurationContext.getTerracottaCommandLineEnvironment(whatFor);
-        IgniteRunnable tsaCreator = () -> AgentController.getInstance().createTsa(instanceId, terracottaServer, cliEnv, envOverrides, Arrays.asList(startUpArgs));
+        Duration inactivityKillerDelay = tsaConfigurationContext.getInactivityKillerDelay();
+        IgniteRunnable tsaCreator = () -> AgentController.getInstance().createTsa(instanceId, terracottaServer, cliEnv, envOverrides, Arrays.asList(startUpArgs), inactivityKillerDelay);
         executor.execute(agentID, tsaCreator);
         return this;
     }

--- a/client-internal/src/main/java/org/terracotta/angela/client/config/TsaConfigurationContext.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/config/TsaConfigurationContext.java
@@ -19,6 +19,8 @@ import org.terracotta.angela.common.TerracottaCommandLineEnvironment;
 import org.terracotta.angela.common.tcconfig.License;
 import org.terracotta.angela.common.topology.Topology;
 
+import java.time.Duration;
+
 public interface TsaConfigurationContext {
   Topology getTopology();
 
@@ -27,6 +29,11 @@ public interface TsaConfigurationContext {
   String getClusterName();
 
   TerracottaCommandLineEnvironment getTerracottaCommandLineEnvironment(String whatFor);
+
+  /**
+   * TSA will be killed if notthing happens in a specified amount of time
+   */
+  Duration getInactivityKillerDelay();
 
   interface TerracottaCommandLineEnvironmentKeys {
     String JCMD = "Jcmd";

--- a/client-internal/src/main/java/org/terracotta/angela/client/config/custom/CustomTsaConfigurationContext.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/config/custom/CustomTsaConfigurationContext.java
@@ -20,6 +20,7 @@ import org.terracotta.angela.common.TerracottaCommandLineEnvironment;
 import org.terracotta.angela.common.tcconfig.License;
 import org.terracotta.angela.common.topology.Topology;
 
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -29,6 +30,7 @@ public class CustomTsaConfigurationContext implements TsaConfigurationContext {
   private String clusterName;
   private final Map<String, TerracottaCommandLineEnvironment> terracottaCommandLineEnvironments = new HashMap<>();
   private TerracottaCommandLineEnvironment defaultTerracottaCommandLineEnvironment = TerracottaCommandLineEnvironment.DEFAULT;
+  private Duration inactivityKillerDelay = Duration.ZERO; // disabled
 
   protected CustomTsaConfigurationContext() {
   }
@@ -67,6 +69,19 @@ public class CustomTsaConfigurationContext implements TsaConfigurationContext {
   public TerracottaCommandLineEnvironment getTerracottaCommandLineEnvironment(String key) {
     TerracottaCommandLineEnvironment tce = terracottaCommandLineEnvironments.get(key);
     return tce != null ? tce : defaultTerracottaCommandLineEnvironment;
+  }
+
+  @Override
+  public Duration getInactivityKillerDelay() {
+    return inactivityKillerDelay;
+  }
+
+  /**
+   * TSA will be killed if no activity after this period of time in the logs
+   */
+  public CustomTsaConfigurationContext setInactivityKillerDelay(Duration inactivityKillerDelay) {
+    this.inactivityKillerDelay = inactivityKillerDelay;
+    return this;
   }
 
   public CustomTsaConfigurationContext terracottaCommandLineEnvironment(TerracottaCommandLineEnvironment terracottaCommandLineEnvironment) {

--- a/common/src/main/java/org/terracotta/angela/common/TerracottaServerInstance.java
+++ b/common/src/main/java/org/terracotta/angela/common/TerracottaServerInstance.java
@@ -29,6 +29,7 @@ import org.terracotta.angela.common.util.Jcmd;
 
 import java.io.Closeable;
 import java.io.File;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -86,8 +87,8 @@ public class TerracottaServerInstance implements Closeable {
     return distribution;
   }
 
-  public void create(TerracottaCommandLineEnvironment env, Map<String, String> envOverrides, List<String> startUpArgs) {
-    setServerHandle(this.distributionController.createTsa(terracottaServer, kitDir, workingDir, topology, proxiedPorts, env, envOverrides, startUpArgs));
+  public void create(TerracottaCommandLineEnvironment env, Map<String, String> envOverrides, List<String> startUpArgs, Duration inactivityKillerDelay) {
+    setServerHandle(this.distributionController.createTsa(terracottaServer, kitDir, workingDir, topology, proxiedPorts, env, envOverrides, startUpArgs, inactivityKillerDelay));
   }
 
   private synchronized TerracottaServerHandle getServerHandle() {

--- a/common/src/main/java/org/terracotta/angela/common/distribution/Distribution102Controller.java
+++ b/common/src/main/java/org/terracotta/angela/common/distribution/Distribution102Controller.java
@@ -55,6 +55,7 @@ import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -88,7 +89,8 @@ public class Distribution102Controller extends DistributionController {
   @Override
   public TerracottaServerHandle createTsa(TerracottaServer terracottaServer, File kitDir, File workingDir,
                                           Topology topology, Map<ServerSymbolicName, Integer> proxiedPorts,
-                                          TerracottaCommandLineEnvironment tcEnv, Map<String, String> envOverrides, List<String> startUpArgs) {
+                                          TerracottaCommandLineEnvironment tcEnv, Map<String, String> envOverrides,
+                                          List<String> startUpArgs, Duration inactivityKillerDelay) {
     Map<String, String> env = tcEnv.buildEnv(envOverrides);
     AtomicReference<TerracottaServerState> stateRef = new AtomicReference<>(TerracottaServerState.STOPPED);
     AtomicInteger javaPid = new AtomicInteger(-1);

--- a/common/src/main/java/org/terracotta/angela/common/distribution/Distribution107InlineController.java
+++ b/common/src/main/java/org/terracotta/angela/common/distribution/Distribution107InlineController.java
@@ -23,9 +23,12 @@ import org.terracotta.angela.common.TerracottaServerState;
 import org.terracotta.angela.common.tcconfig.ServerSymbolicName;
 import org.terracotta.angela.common.tcconfig.TerracottaServer;
 import org.terracotta.angela.common.topology.Topology;
+import org.terracotta.angela.common.util.ActivityTracker;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.OutputStream;
+import java.io.UncheckedIOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URL;
@@ -33,6 +36,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -52,21 +56,29 @@ public class Distribution107InlineController extends Distribution107Controller {
 
   @Override
   public TerracottaServerHandle createTsa(TerracottaServer terracottaServer, File kitDir, File workingDir,
-                                                   Topology topology, Map<ServerSymbolicName, Integer> proxiedPorts,
-                                                   TerracottaCommandLineEnvironment tcEnv, Map<String, String> envOverrides, List<String> startUpArgs) {
+                                          Topology topology, Map<ServerSymbolicName, Integer> proxiedPorts,
+                                          TerracottaCommandLineEnvironment tcEnv, Map<String, String> envOverrides,
+                                          List<String> startUpArgs, Duration inactivityKillerDelay) {
     List<String> options = startUpArgs != null && !startUpArgs.isEmpty() ? addServerHome(startUpArgs, workingDir) : addOptions(terracottaServer, workingDir);
 
-    return createServer(kitDir.toPath(), terracottaServer.getServerSymbolicName().getSymbolicName(), workingDir.toPath(), options);
+    return createServer(kitDir.toPath(), terracottaServer.getServerSymbolicName().getSymbolicName(), workingDir.toPath(), options, inactivityKillerDelay);
   }
 
-  private TerracottaServerHandle createServer(Path kitDir, String serverName, Path serverWorking, List<String> cmd) {
+  private TerracottaServerHandle createServer(Path kitDir, String serverName, Path serverWorking, List<String> cmd, Duration inactivityKillerDelay) {
     LOGGER.debug("Creating TSA server: {} at: {} from: {} with CLI: {}", serverName, serverWorking, kitDir, String.join(" ", cmd));
-    AtomicReference<Object> ref = new AtomicReference<>(startIsolatedServer(kitDir, serverName, serverWorking, cmd));
+    ActivityTracker inactivityTracker = ActivityTracker.of(inactivityKillerDelay);
+    TrackedOutputStream trackedOutputStream;
+    try {
+      trackedOutputStream = new TrackedOutputStream(inactivityTracker, Files.newOutputStream(serverWorking.resolve("stdout.txt"), StandardOpenOption.CREATE, StandardOpenOption.APPEND));
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+    AtomicReference<Object> ref = new AtomicReference<>(startIsolatedServer(kitDir, serverWorking, cmd, trackedOutputStream));
     AtomicBoolean isAlive = new AtomicBoolean(true);
-    Thread t = new Thread(()->{
+    Thread t = new Thread(() -> {
       try {
-        while ((Boolean)invokeOnObject(ref.get(), "waitUntilShutdown")) {
-          ref.set(startIsolatedServer(kitDir, serverName, serverWorking, cmd));
+        while ((Boolean) invokeOnObject(ref.get(), "waitUntilShutdown")) {
+          ref.set(startIsolatedServer(kitDir, serverWorking, cmd, trackedOutputStream));
         }
       } catch (Throwable tt) {
         ref.set(null);
@@ -77,8 +89,7 @@ public class Distribution107InlineController extends Distribution107Controller {
     t.setDaemon(true);
     t.start();
 
-    return new TerracottaServerHandle() {
-
+    final TerracottaServerHandle handle = new TerracottaServerHandle() {
       @Override
       public TerracottaServerState getState() {
         if (isAlive()) {
@@ -112,7 +123,7 @@ public class Distribution107InlineController extends Distribution107Controller {
               }
               return TerracottaServerState.STARTED_AS_PASSIVE;
             default:
-              return (!isAlive() || ((Boolean)invoke("isStopped"))) ? TerracottaServerState.STOPPED : TerracottaServerState.STARTING;
+              return (!isAlive() || ((Boolean) invoke("isStopped"))) ? TerracottaServerState.STOPPED : TerracottaServerState.STARTING;
           }
         } else {
           return TerracottaServerState.STOPPED;
@@ -131,6 +142,7 @@ public class Distribution107InlineController extends Distribution107Controller {
 
       @Override
       public void stop() {
+        inactivityTracker.stop();
         boolean stop = true;
         while (stop) {
           stop = Boolean.parseBoolean(invokeOnServerMBean("Server", "stopAndWait", null));
@@ -144,10 +156,10 @@ public class Distribution107InlineController extends Distribution107Controller {
           m.setAccessible(true);
           return m.invoke(serverJMX, target, call, arg).toString();
         } catch (NoSuchMethodException |
-                SecurityException |
-                IllegalAccessException |
-                IllegalArgumentException |
-                InvocationTargetException s) {
+            SecurityException |
+            IllegalAccessException |
+            IllegalArgumentException |
+            InvocationTargetException s) {
           LOGGER.warn("unable to call", s);
           return "ERROR";
         }
@@ -157,12 +169,23 @@ public class Distribution107InlineController extends Distribution107Controller {
         return invokeOnObject(ref.get(), method);
       }
     };
+
+    inactivityTracker.onInactivity(() -> {
+      LOGGER.error("************************************************************");
+      LOGGER.error("Server: " + serverName + " will be stopped or killed because it is inactive since: " + inactivityKillerDelay);
+      LOGGER.error("This situation must be inspected because it could be created by a thread preventing the server to shutdown");
+      LOGGER.error("If the inactivity is expected, please increase the 'InactivityKillerDelay' in TSA configuration");
+      LOGGER.error("************************************************************");
+      handle.stop();
+    });
+
+    return handle;
   }
 
-  private static Object invokeOnObject(Object server, String method, Object...args) {
+  private static Object invokeOnObject(Object server, String method, Object... args) {
     try {
       Class<?>[] clazz = new Class<?>[args.length];
-      for (int x=0;x<args.length;x++) {
+      for (int x = 0; x < args.length; x++) {
         Class<?> sig = args[x] != null ? args[x].getClass() : null;
         clazz[x] = sig;
       }
@@ -175,7 +198,7 @@ public class Distribution107InlineController extends Distribution107Controller {
     }
   }
 
-  private synchronized Object startIsolatedServer(Path kitDir, String serverName, Path serverWorking, List<String> cmd) {
+  private synchronized Object startIsolatedServer(Path kitDir, Path serverWorking, List<String> cmd, TrackedOutputStream outputStream) {
     Path tc = kitDir.resolve(Paths.get("server", "lib", "tc.jar"));
     ClassLoader oldLoader = Thread.currentThread().getContextClassLoader();
     Thread.currentThread().setContextClassLoader(null);
@@ -184,9 +207,11 @@ public class Distribution107InlineController extends Distribution107Controller {
       URL resource = serverWorking.toUri().toURL();
       System.setProperty("tc.install-root", kitDir.resolve("server").toString());
 
-      ClassLoader loader = new IsolatedClassLoader(new URL[] {resource, url});
+      ClassLoader loader = new IsolatedClassLoader(new URL[]{resource, url});
       Method m = Class.forName("com.tc.server.TCServerMain", true, loader).getMethod("createServer", List.class, OutputStream.class);
-      return m.invoke(null, cmd, Files.newOutputStream(serverWorking.resolve("stdout.txt"), StandardOpenOption.CREATE, StandardOpenOption.APPEND));
+      Object o = m.invoke(null, cmd, outputStream);
+      outputStream.getActivityTracker().start();
+      return o;
     } catch (RuntimeException mal) {
       throw mal;
     } catch (Exception e) {

--- a/common/src/main/java/org/terracotta/angela/common/distribution/Distribution43Controller.java
+++ b/common/src/main/java/org/terracotta/angela/common/distribution/Distribution43Controller.java
@@ -50,6 +50,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -90,7 +91,8 @@ public class Distribution43Controller extends DistributionController {
   @Override
   public TerracottaServerHandle createTsa(TerracottaServer terracottaServer, File kitDir, File workingDir,
                                           Topology topology, Map<ServerSymbolicName, Integer> proxiedPorts,
-                                          TerracottaCommandLineEnvironment tcEnv, Map<String, String> envOverrides, List<String> startUpArgs) {
+                                          TerracottaCommandLineEnvironment tcEnv, Map<String, String> envOverrides,
+                                          List<String> startUpArgs, Duration inactivityKillerDelay) {
     AtomicReference<TerracottaServerState> stateRef = new AtomicReference<>(STOPPED);
     AtomicReference<TerracottaServerState> tempStateRef = new AtomicReference<>(STOPPED);
 

--- a/common/src/main/java/org/terracotta/angela/common/distribution/DistributionController.java
+++ b/common/src/main/java/org/terracotta/angela/common/distribution/DistributionController.java
@@ -33,6 +33,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.net.URI;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -51,7 +52,7 @@ public abstract class DistributionController {
     this.distribution = distribution;
   }
 
-  public abstract TerracottaServerHandle createTsa(TerracottaServer terracottaServer, File kitDir, File workingDir, Topology topology, Map<ServerSymbolicName, Integer> proxiedPorts, TerracottaCommandLineEnvironment tcEnv, Map<String, String> envOverrides, List<String> startUpArgs);
+  public abstract TerracottaServerHandle createTsa(TerracottaServer terracottaServer, File kitDir, File workingDir, Topology topology, Map<ServerSymbolicName, Integer> proxiedPorts, TerracottaCommandLineEnvironment tcEnv, Map<String, String> envOverrides, List<String> startUpArgs, Duration inactivityKillerDelay);
 
   public abstract TerracottaManagementServerInstance.TerracottaManagementServerInstanceProcess startTms(File kitDir, File workingDir, TerracottaCommandLineEnvironment env, Map<String, String> envOverrides);
 

--- a/common/src/main/java/org/terracotta/angela/common/distribution/TrackedOutputStream.java
+++ b/common/src/main/java/org/terracotta/angela/common/distribution/TrackedOutputStream.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.angela.common.distribution;
+
+import org.jetbrains.annotations.NotNull;
+import org.terracotta.angela.common.util.ActivityTracker;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * @author Mathieu Carbou
+ */
+public class TrackedOutputStream extends OutputStream {
+  private final ActivityTracker activityTracker;
+  private final OutputStream delegate;
+
+  public TrackedOutputStream(ActivityTracker activityTracker, OutputStream delegate) {
+    this.activityTracker = activityTracker;
+    this.delegate = delegate;
+  }
+
+  public ActivityTracker getActivityTracker() {
+    return activityTracker;
+  }
+
+  @Override
+  public void write(int b) throws IOException {
+    activityTracker.touch();
+    delegate.write(b);
+  }
+
+  @Override
+  public void write(@NotNull byte[] b) throws IOException {
+    activityTracker.touch();
+    delegate.write(b);
+  }
+
+  @Override
+  public void write(@NotNull byte[] b, int off, int len) throws IOException {
+    activityTracker.touch();
+    delegate.write(b, off, len);
+  }
+
+  @Override
+  public void flush() throws IOException {delegate.flush();}
+
+  @Override
+  public void close() throws IOException {delegate.close();}
+}

--- a/common/src/main/java/org/terracotta/angela/common/util/ActivityTracker.java
+++ b/common/src/main/java/org/terracotta/angela/common/util/ActivityTracker.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.angela.common.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedTransferQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TransferQueue;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Tracker of inactivity
+ *
+ * @author Mathieu Carbou
+ */
+public class ActivityTracker implements Closeable {
+
+  private static final Logger logger = LoggerFactory.getLogger(ActivityTracker.class);
+
+  private final Duration inactivityDelay;
+  private final Map<String, Collection<Runnable>> listeners = new ConcurrentHashMap<>();
+  private final TransferQueue<Boolean> activity = new LinkedTransferQueue<>();
+  private final boolean enabled;
+  private final AtomicReference<Thread> monitor = new AtomicReference<>();
+
+  private ActivityTracker(Duration inactivityDelay) {
+    this.enabled = !inactivityDelay.equals(Duration.ZERO);
+    this.inactivityDelay = inactivityDelay;
+  }
+
+
+  public Duration getInactivityDelay() {
+    return inactivityDelay;
+  }
+
+  @Override
+  public void close() {
+    stop();
+  }
+
+  public void onInactivity(Runnable runnable) {
+    if (enabled) {
+      getListeners("inactivity").add(runnable);
+    }
+  }
+
+  public void onStart(Runnable runnable) {
+    if (enabled) {
+      getListeners("start").add(runnable);
+    }
+  }
+
+  public void onStop(Runnable runnable) {
+    if (enabled) {
+      getListeners("stop").add(runnable);
+    }
+  }
+
+  /**
+   * Record any activity
+   */
+  public void touch() {
+    if (enabled) {
+      activity.tryTransfer(Boolean.TRUE);
+    }
+  }
+
+  public boolean isRunning() {
+    return monitor.get() != null;
+  }
+
+  public void stop() {
+    internalStop()
+        .filter(thread -> thread != Thread.currentThread())
+        .ifPresent(thread -> {
+          try {
+            thread.join();
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+          }
+        });
+  }
+
+  public void start() {
+    if (enabled && !isRunning()) {
+      CountDownLatch started = new CountDownLatch(1);
+      Thread prev = monitor.getAndUpdate(thread -> {
+        if (thread == null) {
+          thread = new Thread(() -> {
+            try {
+              started.countDown();
+              while (isRunning()) {
+                if (activity.poll(inactivityDelay.toMillis(), TimeUnit.MILLISECONDS) == null) {
+                  // timeout and no new element => inactivity
+                  getListeners("inactivity").forEach(runnable -> {
+                    try {
+                      runnable.run();
+                    } catch (RuntimeException e) {
+                      logger.error(e.getMessage(), e);
+                    }
+                  });
+                }
+              }
+            } catch (InterruptedException ignored) {
+            } finally {
+              internalStop();
+            }
+          });
+          thread.setName("ActivityTracker:" + inactivityDelay + ":" + thread.hashCode());
+          thread.setDaemon(true);
+          thread.start();
+        }
+        return thread;
+      });
+      if (prev == null) {
+        try {
+          started.await();
+          getListeners("start").forEach(runnable -> {
+            try {
+              runnable.run();
+            } catch (RuntimeException e) {
+              logger.error(e.getMessage(), e);
+            }
+          });
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+    }
+  }
+
+  private Optional<Thread> internalStop() {
+    Thread prev = monitor.getAndSet(null);
+    if (prev != null) {
+      getListeners("stop").forEach(runnable -> {
+        try {
+          runnable.run();
+        } catch (RuntimeException e) {
+          logger.error(e.getMessage(), e);
+        }
+      });
+    }
+    return Optional.ofNullable(prev);
+  }
+
+  private Collection<Runnable> getListeners(String event) {
+    return listeners.compute(event, (e, listeners) -> listeners != null ? listeners : new CopyOnWriteArrayList<>());
+  }
+
+  public static ActivityTracker of(Duration inactivityKillerDelay) {
+    return new ActivityTracker(inactivityKillerDelay);
+  }
+}

--- a/common/src/test/java/org/terracotta/angela/common/util/ActivityTrackerTest.java
+++ b/common/src/test/java/org/terracotta/angela/common/util/ActivityTrackerTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.angela.common.util;
+
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.lang.Thread.sleep;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Mathieu Carbou
+ */
+public class ActivityTrackerTest {
+
+  @Test
+  public void startStop() {
+    try (ActivityTracker activityTracker = ActivityTracker.of(Duration.ofSeconds(1))) {
+      assertFalse(activityTracker.isRunning());
+      activityTracker.start();
+      assertTrue(activityTracker.isRunning());
+      activityTracker.stop();
+      assertFalse(activityTracker.isRunning());
+    }
+  }
+
+  @Test
+  public void events() throws InterruptedException {
+    try (ActivityTracker activityTracker = ActivityTracker.of(Duration.ofSeconds(1))) {
+      AtomicInteger inactives = new AtomicInteger();
+      AtomicInteger starts = new AtomicInteger();
+      AtomicInteger stops = new AtomicInteger();
+
+      activityTracker.onStart(() -> {
+        System.out.println("onStart()");
+        starts.incrementAndGet();
+      });
+      activityTracker.onStop(() -> {
+        System.out.println("onStop()");
+        stops.incrementAndGet();
+      });
+      activityTracker.onInactivity(() -> {
+        System.out.println("onInactivity()");
+        inactives.incrementAndGet();
+      });
+
+      // not started
+      sleep(2_000);
+      assertThat(inactives.get(), is(equalTo(0)));
+
+      // on start
+      activityTracker.start();
+      assertThat(starts.get(), is(equalTo(1)));
+
+      // inactive
+      sleep(2_000);
+      int now1 = inactives.get();
+      assertTrue(now1 >= 1);
+
+      // on stop
+      activityTracker.stop();
+      assertThat(stops.get(), is(equalTo(1)));
+
+      // stopped
+      sleep(2_000);
+      int now2 = inactives.get();
+      assertThat(now2, is(equalTo(now1 + 1)));
+
+      // restart
+      activityTracker.start();
+      assertThat(starts.get(), is(equalTo(2)));
+
+      // inactive again
+      sleep(2_000);
+      int now3 = inactives.get();
+      assertTrue(now3 >= 1);
+
+      // stopped again
+      activityTracker.stop();
+      assertThat(stops.get(), is(equalTo(2)));
+    }
+  }
+
+  @Test
+  public void stopOnInactivity() throws InterruptedException {
+    try (ActivityTracker activityTracker = ActivityTracker.of(Duration.ofSeconds(1))) {
+      AtomicInteger stops = new AtomicInteger();
+      activityTracker.onStop(stops::incrementAndGet);
+      activityTracker.onInactivity(activityTracker::stop);
+      activityTracker.start();
+
+      sleep(2_000);
+      assertThat(stops.get(), is(equalTo(1)));
+      assertFalse(activityTracker.isRunning());
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -337,12 +337,6 @@
                     <dependencyConvergence>
                       <uniqueVersions>true</uniqueVersions>
                     </dependencyConvergence>
-                    <requireJavaVersion>
-                      <version>[${java.build.version},)</version>
-                    </requireJavaVersion>
-                    <requireMavenVersion>
-                      <version>[${maven.version},)</version>
-                    </requireMavenVersion>
                     <bannedDependencies>
                       <excludes>
                         <exclude>com.github.stefanbirkner:system-rules</exclude>


### PR DESCRIPTION
1) Add an activity tracker in Angela to automatically kill (if configured) TSA processes when no activity seen  after  a configured duration. By default, this feature is disabled.

This is only to be used in case it can temporarily unlock some tests. 
I.e. right now in TcDbTest project, ~50 tests are failing because of a core issue preventing servers to be stopped.

2) Also support custom tms props when using a custom kit for TMS, now that tms props are copied in the work dir.