### PR TITLE
Added more API to AngelaRule

### DIFF
--- a/client-internal/pom.xml
+++ b/client-internal/pom.xml
@@ -67,6 +67,10 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.terracotta</groupId>
+      <artifactId>terracotta-utilities-test-tools</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-all</artifactId>
       <scope>provided</scope>

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -71,11 +71,6 @@
       <version>2.8.0</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.terracotta</groupId>
-      <artifactId>terracotta-utilities-test-tools</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <!-- This is required to pass the 'terracotta.version' from the pom, via the versions.properties resource -->


### PR DESCRIPTION
All these API are factored out from the DynamicConfigIT test in platform: their right place is inside this rule since they are query methods regarding the topology / states and assertions on server logs