### PR TITLE
Remove POM repositories element

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>terracotta-parent</artifactId>
-    <version>5.20</version>
+    <version>5.21</version>
   </parent>
 
   <artifactId>angela-root</artifactId>


### PR DESCRIPTION
This commit updates the terracotta-parent to remove the snapshot
repositories.

There's another update needed for 3.3.18 -- second PR once I determine how to accomplish it.