### PR TITLE
Apply exclusions to correct dependency convergence failures

### DIFF
--- a/agent-lib/pom.xml
+++ b/agent-lib/pom.xml
@@ -41,6 +41,12 @@
     <dependency>
       <groupId>org.terracotta</groupId>
       <artifactId>angela-common</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/client-internal/pom.xml
+++ b/client-internal/pom.xml
@@ -51,10 +51,22 @@
     <dependency>
       <groupId>org.terracotta</groupId>
       <artifactId>angela-common</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.terracotta</groupId>
       <artifactId>angela-agent-lib</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.rest-assured</groupId>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -38,6 +38,12 @@
     <dependency>
       <groupId>org.terracotta</groupId>
       <artifactId>angela</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -108,11 +108,23 @@
         <groupId>org.terracotta</groupId>
         <artifactId>terracotta-utilities-port-chooser</artifactId>
         <version>${terracotta-utilities.range.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.terracotta</groupId>
         <artifactId>terracotta-utilities-test-tools</artifactId>
         <version>${terracotta-utilities.range.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.ignite</groupId>


### PR DESCRIPTION
Several modules fail dependency convergence testing apparently due
to Maven's use of the base SLF4J version for convergence testing
when actual dependency resolution properly resolves to the latest
version in the range.  This commit adds a few exclusions to
correct this problem.