### PR TITLE
Add settings.xml per project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target/
 *.iml
 .DS_Store
 /.mvn/wrapper/maven-wrapper.jar
+/.mvn/repository

--- a/README.md
+++ b/README.md
@@ -147,6 +147,13 @@ We expect the TSA to contain one Terracotta server running on localhost, and thi
 
 Full example : See class [EhcacheTest](integration-test/src/test/java/org/terracotta/angela/EhcacheTest.java)
 
+## IMPORTANT: settings.xml
+
+You can run all the Maven commands with `-s settings.xml` to use the project's settings.xml
+and isolate downloaded libraries inside. Change the repo location to point to your default m2 home if needed.
+
+Example: `./mvnw -s settings.xml clean install`
+
 ## How to build
 
     mvn clean install

--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright Terracotta, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <localRepository>.mvn/repository</localRepository>
+  <!--<localRepository>{user.home}/.m2/repository</localRepository>-->
+
+</settings>


### PR DESCRIPTION
I'd like that we have such things per project (`./mvn -s settings.xml ...`), that could be optionally used to:

1. make sure we don't miss any repo for the project
2. isolate the Maven repository per project, which makes sure no library will be found locally and coming from elsewhere not defined in the pom/settings.
3. not be impacted by a global settings.xml that could contain overrides, mirrors, etc
4. avoid us to having to deal with all the troubles coming from settings.xml files  repo and mirrors

In this specific case for platform, the settings is blank because the project runs fine with declared repos in the parent pom.