### PR TITLE
ClusterGroupEmptyException: Topology projection is empty

### DIFF
--- a/agent-lib/src/main/java/org/terracotta/angela/common/cluster/AtomicBoolean.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/common/cluster/AtomicBoolean.java
@@ -15,12 +15,16 @@
  */
 package org.terracotta.angela.common.cluster;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteAtomicLong;
 
-public class AtomicBoolean {
+import java.io.Serializable;
 
+public class AtomicBoolean implements Serializable {
+  private static final long serialVersionUID = 1L;
   private final String name;
+  @SuppressFBWarnings("SE_BAD_FIELD")
   private final IgniteAtomicLong igniteCounter;
 
   AtomicBoolean(Ignite ignite, String name, boolean initVal) {

--- a/agent-lib/src/main/java/org/terracotta/angela/common/cluster/AtomicCounter.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/common/cluster/AtomicCounter.java
@@ -15,12 +15,16 @@
  */
 package org.terracotta.angela.common.cluster;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteAtomicLong;
 
-public class AtomicCounter {
+import java.io.Serializable;
 
+public class AtomicCounter implements Serializable {
+  private static final long serialVersionUID = 1L;
   private final String name;
+  @SuppressFBWarnings("SE_BAD_FIELD")
   private final IgniteAtomicLong igniteCounter;
 
   AtomicCounter(Ignite ignite, String name, long initVal) {

--- a/agent-lib/src/main/java/org/terracotta/angela/common/cluster/AtomicReference.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/common/cluster/AtomicReference.java
@@ -15,11 +15,16 @@
  */
 package org.terracotta.angela.common.cluster;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteAtomicReference;
 
-public class AtomicReference<T> {
+import java.io.Serializable;
 
+public class AtomicReference<T> implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  @SuppressFBWarnings("SE_BAD_FIELD")
   private final IgniteAtomicReference<T> igniteReference;
 
   AtomicReference(Ignite ignite, String name, T initialValue) {

--- a/agent-lib/src/main/java/org/terracotta/angela/common/cluster/Barrier.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/common/cluster/Barrier.java
@@ -15,18 +15,24 @@
  */
 package org.terracotta.angela.common.cluster;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteAtomicLong;
 import org.apache.ignite.IgniteCountDownLatch;
 
+import java.io.Serializable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-public class Barrier {
+public class Barrier implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  @SuppressFBWarnings("SE_BAD_FIELD")
   private final Ignite ignite;
   private final int count;
   private final int index;
   private final String name;
+  @SuppressFBWarnings("SE_BAD_FIELD")
   private volatile IgniteCountDownLatch countDownLatch;
   private volatile int resetCount;
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <terracotta-utilities.range.version>[${terracotta-utilities.base.version},)</terracotta-utilities.range.version>
 
     <!-- Third-party dependencies -->
-    <ignite.version>2.12.0</ignite.version>
+    <ignite.version>2.14.0</ignite.version>
     <json-path.version>4.3.1</json-path.version>
     <hamcrest.version>1.3</hamcrest.version>
     <junit.version>4.12</junit.version>


### PR DESCRIPTION
added some tests regarding 2 cases:
1. deadlock in case a client job would do a system.exit
2. better exception reporting in case a job execution cannot get any result because the ignite jvm was killed abruptly

also added some missing serializable and upgraded angela version