### PR TITLE
Allow a kit to not have any client folder

### DIFF
--- a/agent-lib/src/main/java/org/terracotta/angela/agent/kit/LocalKitManager.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/agent/kit/LocalKitManager.java
@@ -182,6 +182,11 @@ public class LocalKitManager extends KitManager {
       String clientJarsRootFolderName = distribution.createDistributionController()
           .clientJarsRootFolderName(distribution);
 
+      if (!Files.exists(kitInstallationPath.resolve(clientJarsRootFolderName))) {
+        logger.warn("KIT CLIENT FOLDER '{}' IS MISSING: SKIPPING DISCOVERY OF KIT CLIENT JARS", clientJarsRootFolderName);
+        return;
+      }
+
       List<File> clientJars;
       try (Stream<Path> stream = Files.walk(kitInstallationPath.resolve(clientJarsRootFolderName))) {
         clientJars = stream


### PR DESCRIPTION
Bug discovered in PR https://github.com/Terracotta-OSS/terracotta-platform/pull/1181.

Angela does not support a kit without client folder and crashes trying to walk into the client folder to discover client libs.