### PR TITLE
Switch to IBM copyright notice

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,5 +1,6 @@
 #
 # Copyright Terracotta, Inc.
+# Copyright Super iPaaS Integration LLC, an IBM Company 2024
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/agent-lib/pom.xml
+++ b/agent-lib/pom.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ The contents of this file are subject to the Terracotta Public License Version
-  ~ 2.0 (the "License"); You may not use this file except in compliance with the
-  ~ License. You may obtain a copy of the License at
+  ~ Copyright Terracotta, Inc.
+  ~ Copyright Super iPaaS Integration LLC, an IBM Company 2024
   ~
-  ~ http://terracotta.org/legal/terracotta-public-license.
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
   ~
-  ~ Software distributed under the License is distributed on an "AS IS" basis,
-  ~ WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  ~ the specific language governing rights and limitations under the License.
+  ~     http://www.apache.org/licenses/LICENSE-2.0
   ~
-  ~ The Covered Software is Angela.
-  ~
-  ~ The Initial Developer of the Covered Software is
-  ~ Terracotta, Inc., a Software AG company
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"

--- a/agent-lib/src/main/java/org/terracotta/angela/KitResolver.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/KitResolver.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-lib/src/main/java/org/terracotta/angela/agent/Agent.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/agent/Agent.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-lib/src/main/java/org/terracotta/angela/agent/AgentController.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/agent/AgentController.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-lib/src/main/java/org/terracotta/angela/agent/client/RemoteClientManager.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/agent/client/RemoteClientManager.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-lib/src/main/java/org/terracotta/angela/agent/com/AgentExecutor.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/agent/com/AgentExecutor.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-lib/src/main/java/org/terracotta/angela/agent/com/AgentGroup.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/agent/com/AgentGroup.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-lib/src/main/java/org/terracotta/angela/agent/com/AgentID.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/agent/com/AgentID.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-lib/src/main/java/org/terracotta/angela/agent/com/Exceptions.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/agent/com/Exceptions.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-lib/src/main/java/org/terracotta/angela/agent/com/Executor.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/agent/com/Executor.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-lib/src/main/java/org/terracotta/angela/agent/com/FileTransfer.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/agent/com/FileTransfer.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-lib/src/main/java/org/terracotta/angela/agent/com/IgniteAgentGroup.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/agent/com/IgniteAgentGroup.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-lib/src/main/java/org/terracotta/angela/agent/com/IgniteFreeExecutor.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/agent/com/IgniteFreeExecutor.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-lib/src/main/java/org/terracotta/angela/agent/com/IgniteFutureAdapter.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/agent/com/IgniteFutureAdapter.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-lib/src/main/java/org/terracotta/angela/agent/com/IgniteLocalExecutor.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/agent/com/IgniteLocalExecutor.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-lib/src/main/java/org/terracotta/angela/agent/com/IgniteSshRemoteExecutor.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/agent/com/IgniteSshRemoteExecutor.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-lib/src/main/java/org/terracotta/angela/agent/com/LocalAgentGroup.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/agent/com/LocalAgentGroup.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-lib/src/main/java/org/terracotta/angela/agent/kit/KitManager.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/agent/kit/KitManager.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-lib/src/main/java/org/terracotta/angela/agent/kit/LocalKitManager.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/agent/kit/LocalKitManager.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-lib/src/main/java/org/terracotta/angela/agent/kit/MonitoringInstance.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/agent/kit/MonitoringInstance.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-lib/src/main/java/org/terracotta/angela/agent/kit/RemoteKitManager.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/agent/kit/RemoteKitManager.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-lib/src/main/java/org/terracotta/angela/agent/kit/TerracottaInstall.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/agent/kit/TerracottaInstall.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-lib/src/main/java/org/terracotta/angela/agent/kit/TmsInstall.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/agent/kit/TmsInstall.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-lib/src/main/java/org/terracotta/angela/agent/kit/ToolInstall.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/agent/kit/ToolInstall.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +48,7 @@ public class ToolInstall {
   public File getKitDir() {
     return kitDir;
   }
-  
+
   public Distribution getDistribution() {
     return distribution;
   }

--- a/agent-lib/src/main/java/org/terracotta/angela/agent/kit/VoterInstall.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/agent/kit/VoterInstall.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +33,7 @@ public class VoterInstall {
   private final SecurityRootDirectory securityRootDirectory;
   private final TerracottaCommandLineEnvironment tcEnv;
   private final Map<String, TerracottaVoterInstance> terracottaVoterInstances = new HashMap<>();
-  
+
   public VoterInstall(Distribution distribution, File kitLocation, File workingDir, SecurityRootDirectory securityRootDirectory,
                       TerracottaCommandLineEnvironment tcEnv) {
     this.distribution = distribution;
@@ -45,7 +46,7 @@ public class VoterInstall {
   public File getWorkingDir() {
     return workingDir;
   }
-  
+
   public TerracottaVoterInstance getTerracottaVoterInstance(TerracottaVoter terracottaVoter) {
     synchronized (terracottaVoterInstances) {
       return terracottaVoterInstances.get(terracottaVoter.getId());
@@ -66,11 +67,11 @@ public class VoterInstall {
       return terracottaVoterInstances.size();
     }
   }
-  
+
   public int terracottaVoterInstanceCount() {
     synchronized (terracottaVoterInstances) {
       return terracottaVoterInstances.size();
     }
   }
-  
+
 }

--- a/agent-lib/src/main/java/org/terracotta/angela/common/cluster/AtomicBoolean.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/common/cluster/AtomicBoolean.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-lib/src/main/java/org/terracotta/angela/common/cluster/AtomicCounter.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/common/cluster/AtomicCounter.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-lib/src/main/java/org/terracotta/angela/common/cluster/AtomicReference.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/common/cluster/AtomicReference.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-lib/src/main/java/org/terracotta/angela/common/cluster/Barrier.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/common/cluster/Barrier.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-lib/src/main/java/org/terracotta/angela/common/cluster/Cluster.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/common/cluster/Cluster.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-lib/src/test/java/org/terracotta/angela/agent/kit/LocalKitManagerTest.java
+++ b/agent-lib/src/test/java/org/terracotta/angela/agent/kit/LocalKitManagerTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ The contents of this file are subject to the Terracotta Public License Version
-  ~ 2.0 (the "License"); You may not use this file except in compliance with the
-  ~ License. You may obtain a copy of the License at
+  ~ Copyright Terracotta, Inc.
+  ~ Copyright Super iPaaS Integration LLC, an IBM Company 2024
   ~
-  ~ http://terracotta.org/legal/terracotta-public-license.
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
   ~
-  ~ Software distributed under the License is distributed on an "AS IS" basis,
-  ~ WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  ~ the specific language governing rights and limitations under the License.
+  ~     http://www.apache.org/licenses/LICENSE-2.0
   ~
-  ~ The Covered Software is Angela.
-  ~
-  ~ The Initial Developer of the Covered Software is
-  ~ Terracotta, Inc., a Software AG company
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"

--- a/agent/src/main/resources/angela-logback-debug.xml
+++ b/agent/src/main/resources/angela-logback-debug.xml
@@ -1,18 +1,18 @@
 <!--
-  ~ The contents of this file are subject to the Terracotta Public License Version
-  ~ 2.0 (the "License"); You may not use this file except in compliance with the
-  ~ License. You may obtain a copy of the License at
+  ~ Copyright Terracotta, Inc.
+  ~ Copyright Super iPaaS Integration LLC, an IBM Company 2024
   ~
-  ~ http://terracotta.org/legal/terracotta-public-license.
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
   ~
-  ~ Software distributed under the License is distributed on an "AS IS" basis,
-  ~ WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  ~ the specific language governing rights and limitations under the License.
+  ~     http://www.apache.org/licenses/LICENSE-2.0
   ~
-  ~ The Covered Software is Angela.
-  ~
-  ~ The Initial Developer of the Covered Software is
-  ~ Terracotta, Inc., a Software AG company
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
   -->
 
 <configuration>

--- a/agent/src/main/resources/angela-logback.xml
+++ b/agent/src/main/resources/angela-logback.xml
@@ -1,18 +1,18 @@
 <!--
-  ~ The contents of this file are subject to the Terracotta Public License Version
-  ~ 2.0 (the "License"); You may not use this file except in compliance with the
-  ~ License. You may obtain a copy of the License at
+  ~ Copyright Terracotta, Inc.
+  ~ Copyright Super iPaaS Integration LLC, an IBM Company 2024
   ~
-  ~ http://terracotta.org/legal/terracotta-public-license.
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
   ~
-  ~ Software distributed under the License is distributed on an "AS IS" basis,
-  ~ WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  ~ the specific language governing rights and limitations under the License.
+  ~     http://www.apache.org/licenses/LICENSE-2.0
   ~
-  ~ The Covered Software is Angela.
-  ~
-  ~ The Initial Developer of the Covered Software is
-  ~ Terracotta, Inc., a Software AG company
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
   -->
 
 <configuration>

--- a/angela/pom.xml
+++ b/angela/pom.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ The contents of this file are subject to the Terracotta Public License Version
-  ~ 2.0 (the "License"); You may not use this file except in compliance with the
-  ~ License. You may obtain a copy of the License at
+  ~ Copyright Terracotta, Inc.
+  ~ Copyright Super iPaaS Integration LLC, an IBM Company 2024
   ~
-  ~ http://terracotta.org/legal/terracotta-public-license.
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
   ~
-  ~ Software distributed under the License is distributed on an "AS IS" basis,
-  ~ WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  ~ the specific language governing rights and limitations under the License.
+  ~     http://www.apache.org/licenses/LICENSE-2.0
   ~
-  ~ The Covered Software is Angela.
-  ~
-  ~ The Initial Developer of the Covered Software is
-  ~ Terracotta, Inc., a Software AG company
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"

--- a/angela/src/main/java/org/terracotta/angela/ehc3/Ehc3KitResolver.java
+++ b/angela/src/main/java/org/terracotta/angela/ehc3/Ehc3KitResolver.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/angela/src/main/resources/META-INF/services/org.terracotta.angela.KitResolver
+++ b/angela/src/main/resources/META-INF/services/org.terracotta.angela.KitResolver
@@ -1,18 +1,18 @@
 #
-# The contents of this file are subject to the Terracotta Public License Version
-# 2.0 (the "License"); You may not use this file except in compliance with the
-# License. You may obtain a copy of the License at
+# Copyright Terracotta, Inc.
+# Copyright Super iPaaS Integration LLC, an IBM Company 2024
 #
-# http://terracotta.org/legal/terracotta-public-license.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# Software distributed under the License is distributed on an "AS IS" basis,
-# WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-# the specific language governing rights and limitations under the License.
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
-# The Covered Software is Angela.
-#
-# The Initial Developer of the Covered Software is
-# Terracotta, Inc., a Software AG company
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 org.terracotta.angela.ehc3.Ehc3KitResolver

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,6 @@
 #
 # Copyright Terracotta, Inc.
+# Copyright Super iPaaS Integration LLC, an IBM Company 2024
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/client-internal/pom.xml
+++ b/client-internal/pom.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ The contents of this file are subject to the Terracotta Public License Version
-  ~ 2.0 (the "License"); You may not use this file except in compliance with the
-  ~ License. You may obtain a copy of the License at
+  ~ Copyright Terracotta, Inc.
+  ~ Copyright Super iPaaS Integration LLC, an IBM Company 2024
   ~
-  ~ http://terracotta.org/legal/terracotta-public-license.
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
   ~
-  ~ Software distributed under the License is distributed on an "AS IS" basis,
-  ~ WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  ~ the specific language governing rights and limitations under the License.
+  ~     http://www.apache.org/licenses/LICENSE-2.0
   ~
-  ~ The Covered Software is Angela.
-  ~
-  ~ The Initial Developer of the Covered Software is
-  ~ Terracotta, Inc., a Software AG company
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"

--- a/client-internal/src/main/java/org/terracotta/angela/client/AngelaOrchestrator.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/AngelaOrchestrator.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/main/java/org/terracotta/angela/client/Client.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/Client.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/main/java/org/terracotta/angela/client/ClientArray.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/ClientArray.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/main/java/org/terracotta/angela/client/ClientArrayFuture.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/ClientArrayFuture.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/main/java/org/terracotta/angela/client/ClientJob.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/ClientJob.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/main/java/org/terracotta/angela/client/ClusterFactory.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/ClusterFactory.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/main/java/org/terracotta/angela/client/ClusterMonitor.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/ClusterMonitor.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/main/java/org/terracotta/angela/client/ClusterTool.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/ClusterTool.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/main/java/org/terracotta/angela/client/Cmd.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/Cmd.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/main/java/org/terracotta/angela/client/ConfigTool.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/ConfigTool.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/main/java/org/terracotta/angela/client/Jcmd.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/Jcmd.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/main/java/org/terracotta/angela/client/Tms.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/Tms.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/main/java/org/terracotta/angela/client/TmsHttpClient.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/TmsHttpClient.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/main/java/org/terracotta/angela/client/Tsa.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/Tsa.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/main/java/org/terracotta/angela/client/Voter.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/Voter.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/main/java/org/terracotta/angela/client/config/ClientArrayConfigurationContext.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/config/ClientArrayConfigurationContext.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/main/java/org/terracotta/angela/client/config/ConfigurationContext.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/config/ConfigurationContext.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/main/java/org/terracotta/angela/client/config/ConfigurationContextVisitor.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/config/ConfigurationContextVisitor.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/main/java/org/terracotta/angela/client/config/MonitoringConfigurationContext.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/config/MonitoringConfigurationContext.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/main/java/org/terracotta/angela/client/config/TmsConfigurationContext.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/config/TmsConfigurationContext.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/main/java/org/terracotta/angela/client/config/ToolConfigurationContext.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/config/ToolConfigurationContext.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/main/java/org/terracotta/angela/client/config/TsaConfigurationContext.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/config/TsaConfigurationContext.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/main/java/org/terracotta/angela/client/config/VoterConfigurationContext.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/config/VoterConfigurationContext.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/main/java/org/terracotta/angela/client/config/custom/CustomClientArrayConfigurationContext.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/config/custom/CustomClientArrayConfigurationContext.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/main/java/org/terracotta/angela/client/config/custom/CustomClusterToolConfigurationContext.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/config/custom/CustomClusterToolConfigurationContext.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/main/java/org/terracotta/angela/client/config/custom/CustomConfigToolConfigurationContext.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/config/custom/CustomConfigToolConfigurationContext.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/main/java/org/terracotta/angela/client/config/custom/CustomConfigurationContext.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/config/custom/CustomConfigurationContext.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/main/java/org/terracotta/angela/client/config/custom/CustomMonitoringConfigurationContext.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/config/custom/CustomMonitoringConfigurationContext.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/main/java/org/terracotta/angela/client/config/custom/CustomTmsConfigurationContext.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/config/custom/CustomTmsConfigurationContext.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/main/java/org/terracotta/angela/client/config/custom/CustomTsaConfigurationContext.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/config/custom/CustomTsaConfigurationContext.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/main/java/org/terracotta/angela/client/config/custom/CustomVoterConfigurationContext.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/config/custom/CustomVoterConfigurationContext.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/main/java/org/terracotta/angela/client/filesystem/RemoteFile.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/filesystem/RemoteFile.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/main/java/org/terracotta/angela/client/filesystem/RemoteFolder.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/filesystem/RemoteFolder.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/main/java/org/terracotta/angela/client/filesystem/TransportableFile.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/filesystem/TransportableFile.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/main/java/org/terracotta/angela/client/net/ClientToServerDisruptor.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/net/ClientToServerDisruptor.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/main/java/org/terracotta/angela/client/net/DisruptionController.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/net/DisruptionController.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/main/java/org/terracotta/angela/client/net/ServerToServerDisruptor.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/net/ServerToServerDisruptor.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/main/java/org/terracotta/angela/client/net/SplitCluster.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/net/SplitCluster.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/main/java/org/terracotta/angela/client/support/hamcrest/AngelaMatchers.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/support/hamcrest/AngelaMatchers.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/main/java/org/terracotta/angela/client/support/junit/AngelaOrchestratorRule.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/support/junit/AngelaOrchestratorRule.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/main/java/org/terracotta/angela/client/support/junit/AngelaRule.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/support/junit/AngelaRule.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/main/java/org/terracotta/angela/client/support/junit/ExtendedTestRule.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/support/junit/ExtendedTestRule.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/main/java/org/terracotta/angela/client/support/junit/ExtraLogging.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/support/junit/ExtraLogging.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/test/java/org/terracotta/angela/client/DummyKitResolver.java
+++ b/client-internal/src/test/java/org/terracotta/angela/client/DummyKitResolver.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/test/java/org/terracotta/angela/client/TsaTest.java
+++ b/client-internal/src/test/java/org/terracotta/angela/client/TsaTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/test/java/org/terracotta/angela/client/config/custom/CustomConfigurationContextTest.java
+++ b/client-internal/src/test/java/org/terracotta/angela/client/config/custom/CustomConfigurationContextTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client-internal/src/test/resources/META-INF/services/org.terracotta.angela.KitResolver
+++ b/client-internal/src/test/resources/META-INF/services/org.terracotta.angela.KitResolver
@@ -1,18 +1,18 @@
 #
-# The contents of this file are subject to the Terracotta Public License Version
-# 2.0 (the "License"); You may not use this file except in compliance with the
-# License. You may obtain a copy of the License at
+# Copyright Terracotta, Inc.
+# Copyright Super iPaaS Integration LLC, an IBM Company 2024
 #
-# http://terracotta.org/legal/terracotta-public-license.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# Software distributed under the License is distributed on an "AS IS" basis,
-# WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-# the specific language governing rights and limitations under the License.
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
-# The Covered Software is Angela.
-#
-# The Initial Developer of the Covered Software is
-# Terracotta, Inc., a Software AG company
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 org.terracotta.angela.client.DummyKitResolver

--- a/client-internal/src/test/resources/logback-test.xml
+++ b/client-internal/src/test/resources/logback-test.xml
@@ -1,18 +1,18 @@
 <!--
-  ~ The contents of this file are subject to the Terracotta Public License Version
-  ~ 2.0 (the "License"); You may not use this file except in compliance with the
-  ~ License. You may obtain a copy of the License at
+  ~ Copyright Terracotta, Inc.
+  ~ Copyright Super iPaaS Integration LLC, an IBM Company 2024
   ~
-  ~ http://terracotta.org/legal/terracotta-public-license.
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
   ~
-  ~ Software distributed under the License is distributed on an "AS IS" basis,
-  ~ WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  ~ the specific language governing rights and limitations under the License.
+  ~     http://www.apache.org/licenses/LICENSE-2.0
   ~
-  ~ The Covered Software is Angela.
-  ~
-  ~ The Initial Developer of the Covered Software is
-  ~ Terracotta, Inc., a Software AG company
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
   -->
 
 <configuration>

--- a/client-internal/src/test/resources/terracotta/10/tc-config-big.xml
+++ b/client-internal/src/test/resources/terracotta/10/tc-config-big.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ The contents of this file are subject to the Terracotta Public License Version
-  ~ 2.0 (the "License"); You may not use this file except in compliance with the
-  ~ License. You may obtain a copy of the License at
+  ~ Copyright Terracotta, Inc.
+  ~ Copyright Super iPaaS Integration LLC, an IBM Company 2024
   ~
-  ~ http://terracotta.org/legal/terracotta-public-license.
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
   ~
-  ~ Software distributed under the License is distributed on an "AS IS" basis,
-  ~ WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  ~ the specific language governing rights and limitations under the License.
+  ~     http://www.apache.org/licenses/LICENSE-2.0
   ~
-  ~ The Covered Software is Angela.
-  ~
-  ~ The Initial Developer of the Covered Software is
-  ~ Terracotta, Inc., a Software AG company
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
   -->
 
 <tc-config xmlns="http://www.terracotta.org/config"

--- a/client-internal/src/test/resources/terracotta/10/tc-config.xml
+++ b/client-internal/src/test/resources/terracotta/10/tc-config.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ The contents of this file are subject to the Terracotta Public License Version
-  ~ 2.0 (the "License"); You may not use this file except in compliance with the
-  ~ License. You may obtain a copy of the License at
+  ~ Copyright Terracotta, Inc.
+  ~ Copyright Super iPaaS Integration LLC, an IBM Company 2024
   ~
-  ~ http://terracotta.org/legal/terracotta-public-license.
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
   ~
-  ~ Software distributed under the License is distributed on an "AS IS" basis,
-  ~ WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  ~ the specific language governing rights and limitations under the License.
+  ~     http://www.apache.org/licenses/LICENSE-2.0
   ~
-  ~ The Covered Software is Angela.
-  ~
-  ~ The Initial Developer of the Covered Software is
-  ~ Terracotta, Inc., a Software AG company
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
   -->
 
 <tc-config xmlns="http://www.terracotta.org/config"

--- a/client-internal/src/test/resources/terracotta/4/tc-config-big.xml
+++ b/client-internal/src/test/resources/terracotta/4/tc-config-big.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ The contents of this file are subject to the Terracotta Public License Version
-  ~ 2.0 (the "License"); You may not use this file except in compliance with the
-  ~ License. You may obtain a copy of the License at
+  ~ Copyright Terracotta, Inc.
+  ~ Copyright Super iPaaS Integration LLC, an IBM Company 2024
   ~
-  ~ http://terracotta.org/legal/terracotta-public-license.
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
   ~
-  ~ Software distributed under the License is distributed on an "AS IS" basis,
-  ~ WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  ~ the specific language governing rights and limitations under the License.
+  ~     http://www.apache.org/licenses/LICENSE-2.0
   ~
-  ~ The Covered Software is Angela.
-  ~
-  ~ The Initial Developer of the Covered Software is
-  ~ Terracotta, Inc., a Software AG company
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
   -->
 
 <tc:tc-config xmlns:tc="http://www.terracotta.org/config"

--- a/client-internal/src/test/resources/terracotta/4/tc-config.xml
+++ b/client-internal/src/test/resources/terracotta/4/tc-config.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ The contents of this file are subject to the Terracotta Public License Version
-  ~ 2.0 (the "License"); You may not use this file except in compliance with the
-  ~ License. You may obtain a copy of the License at
+  ~ Copyright Terracotta, Inc.
+  ~ Copyright Super iPaaS Integration LLC, an IBM Company 2024
   ~
-  ~ http://terracotta.org/legal/terracotta-public-license.
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
   ~
-  ~ Software distributed under the License is distributed on an "AS IS" basis,
-  ~ WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  ~ the specific language governing rights and limitations under the License.
+  ~     http://www.apache.org/licenses/LICENSE-2.0
   ~
-  ~ The Covered Software is Angela.
-  ~
-  ~ The Initial Developer of the Covered Software is
-  ~ Terracotta, Inc., a Software AG company
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
   -->
 
 <tc:tc-config xmlns:tc="http://www.terracotta.org/config"

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ The contents of this file are subject to the Terracotta Public License Version
-  ~ 2.0 (the "License"); You may not use this file except in compliance with the
-  ~ License. You may obtain a copy of the License at
+  ~ Copyright Terracotta, Inc.
+  ~ Copyright Super iPaaS Integration LLC, an IBM Company 2024
   ~
-  ~ http://terracotta.org/legal/terracotta-public-license.
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
   ~
-  ~ Software distributed under the License is distributed on an "AS IS" basis,
-  ~ WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  ~ the specific language governing rights and limitations under the License.
+  ~     http://www.apache.org/licenses/LICENSE-2.0
   ~
-  ~ The Covered Software is Angela.
-  ~
-  ~ The Initial Developer of the Covered Software is
-  ~ Terracotta, Inc., a Software AG company
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"

--- a/common/src/main/java/org/terracotta/angela/common/AngelaProperties.java
+++ b/common/src/main/java/org/terracotta/angela/common/AngelaProperties.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/TerracottaClusterTool.java
+++ b/common/src/main/java/org/terracotta/angela/common/TerracottaClusterTool.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/TerracottaCommandLineEnvironment.java
+++ b/common/src/main/java/org/terracotta/angela/common/TerracottaCommandLineEnvironment.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/TerracottaConfigTool.java
+++ b/common/src/main/java/org/terracotta/angela/common/TerracottaConfigTool.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/TerracottaManagementServerInstance.java
+++ b/common/src/main/java/org/terracotta/angela/common/TerracottaManagementServerInstance.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/TerracottaManagementServerState.java
+++ b/common/src/main/java/org/terracotta/angela/common/TerracottaManagementServerState.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/TerracottaServerHandle.java
+++ b/common/src/main/java/org/terracotta/angela/common/TerracottaServerHandle.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/TerracottaServerInstance.java
+++ b/common/src/main/java/org/terracotta/angela/common/TerracottaServerInstance.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/TerracottaServerState.java
+++ b/common/src/main/java/org/terracotta/angela/common/TerracottaServerState.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/TerracottaToolInstance.java
+++ b/common/src/main/java/org/terracotta/angela/common/TerracottaToolInstance.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/TerracottaVoter.java
+++ b/common/src/main/java/org/terracotta/angela/common/TerracottaVoter.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/TerracottaVoterInstance.java
+++ b/common/src/main/java/org/terracotta/angela/common/TerracottaVoterInstance.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/TerracottaVoterState.java
+++ b/common/src/main/java/org/terracotta/angela/common/TerracottaVoterState.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/ToolException.java
+++ b/common/src/main/java/org/terracotta/angela/common/ToolException.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/ToolExecutionResult.java
+++ b/common/src/main/java/org/terracotta/angela/common/ToolExecutionResult.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/clientconfig/ClientArrayConfig.java
+++ b/common/src/main/java/org/terracotta/angela/common/clientconfig/ClientArrayConfig.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/clientconfig/ClientId.java
+++ b/common/src/main/java/org/terracotta/angela/common/clientconfig/ClientId.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/clientconfig/ClientSymbolicName.java
+++ b/common/src/main/java/org/terracotta/angela/common/clientconfig/ClientSymbolicName.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/distribution/Distribution.java
+++ b/common/src/main/java/org/terracotta/angela/common/distribution/Distribution.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/distribution/Distribution102Controller.java
+++ b/common/src/main/java/org/terracotta/angela/common/distribution/Distribution102Controller.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/distribution/Distribution107Controller.java
+++ b/common/src/main/java/org/terracotta/angela/common/distribution/Distribution107Controller.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/distribution/Distribution107InlineController.java
+++ b/common/src/main/java/org/terracotta/angela/common/distribution/Distribution107InlineController.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -122,7 +123,7 @@ public class Distribution107InlineController extends Distribution107Controller {
           return TerracottaServerState.STOPPED;
         }
       }
-      
+
       public boolean isStopped() {
         Object server = ref.get();
         if (server instanceof Future) {

--- a/common/src/main/java/org/terracotta/angela/common/distribution/Distribution43Controller.java
+++ b/common/src/main/java/org/terracotta/angela/common/distribution/Distribution43Controller.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/distribution/DistributionController.java
+++ b/common/src/main/java/org/terracotta/angela/common/distribution/DistributionController.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/distribution/IsolatedClassLoader.java
+++ b/common/src/main/java/org/terracotta/angela/common/distribution/IsolatedClassLoader.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/distribution/RuntimeOption.java
+++ b/common/src/main/java/org/terracotta/angela/common/distribution/RuntimeOption.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/distribution/TrackedOutputStream.java
+++ b/common/src/main/java/org/terracotta/angela/common/distribution/TrackedOutputStream.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/distribution/WatchedProcess.java
+++ b/common/src/main/java/org/terracotta/angela/common/distribution/WatchedProcess.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/dynamic_cluster/Stripe.java
+++ b/common/src/main/java/org/terracotta/angela/common/dynamic_cluster/Stripe.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/metrics/HardwareMetric.java
+++ b/common/src/main/java/org/terracotta/angela/common/metrics/HardwareMetric.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/metrics/HardwareMetricsCollector.java
+++ b/common/src/main/java/org/terracotta/angela/common/metrics/HardwareMetricsCollector.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/metrics/MonitoringCommand.java
+++ b/common/src/main/java/org/terracotta/angela/common/metrics/MonitoringCommand.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/net/DefaultPortAllocator.java
+++ b/common/src/main/java/org/terracotta/angela/common/net/DefaultPortAllocator.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/net/DisruptionProvider.java
+++ b/common/src/main/java/org/terracotta/angela/common/net/DisruptionProvider.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/net/DisruptionProviderFactory.java
+++ b/common/src/main/java/org/terracotta/angela/common/net/DisruptionProviderFactory.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/net/Disruptor.java
+++ b/common/src/main/java/org/terracotta/angela/common/net/Disruptor.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/net/DisruptorState.java
+++ b/common/src/main/java/org/terracotta/angela/common/net/DisruptorState.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/net/Link.java
+++ b/common/src/main/java/org/terracotta/angela/common/net/Link.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/net/NetCrusherProvider.java
+++ b/common/src/main/java/org/terracotta/angela/common/net/NetCrusherProvider.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/net/PortAllocator.java
+++ b/common/src/main/java/org/terracotta/angela/common/net/PortAllocator.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/provider/ConfigurationManager.java
+++ b/common/src/main/java/org/terracotta/angela/common/provider/ConfigurationManager.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/provider/DynamicConfigManager.java
+++ b/common/src/main/java/org/terracotta/angela/common/provider/DynamicConfigManager.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/provider/TcConfigManager.java
+++ b/common/src/main/java/org/terracotta/angela/common/provider/TcConfigManager.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/tcconfig/EnterpriseTcConfig.java
+++ b/common/src/main/java/org/terracotta/angela/common/tcconfig/EnterpriseTcConfig.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/tcconfig/License.java
+++ b/common/src/main/java/org/terracotta/angela/common/tcconfig/License.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/tcconfig/NamedSecurityRootDirectory.java
+++ b/common/src/main/java/org/terracotta/angela/common/tcconfig/NamedSecurityRootDirectory.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/tcconfig/SecureTcConfig.java
+++ b/common/src/main/java/org/terracotta/angela/common/tcconfig/SecureTcConfig.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/tcconfig/SecurityRootDirectory.java
+++ b/common/src/main/java/org/terracotta/angela/common/tcconfig/SecurityRootDirectory.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/tcconfig/ServerSymbolicName.java
+++ b/common/src/main/java/org/terracotta/angela/common/tcconfig/ServerSymbolicName.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/tcconfig/TcConfig.java
+++ b/common/src/main/java/org/terracotta/angela/common/tcconfig/TcConfig.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/tcconfig/TerracottaServer.java
+++ b/common/src/main/java/org/terracotta/angela/common/tcconfig/TerracottaServer.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/tcconfig/TsaConfig.java
+++ b/common/src/main/java/org/terracotta/angela/common/tcconfig/TsaConfig.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/tcconfig/TsaStripeConfig.java
+++ b/common/src/main/java/org/terracotta/angela/common/tcconfig/TsaStripeConfig.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/tcconfig/holders/TcConfig10Holder.java
+++ b/common/src/main/java/org/terracotta/angela/common/tcconfig/holders/TcConfig10Holder.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/tcconfig/holders/TcConfig8Holder.java
+++ b/common/src/main/java/org/terracotta/angela/common/tcconfig/holders/TcConfig8Holder.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/tcconfig/holders/TcConfig9Holder.java
+++ b/common/src/main/java/org/terracotta/angela/common/tcconfig/holders/TcConfig9Holder.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/tcconfig/holders/TcConfigHolder.java
+++ b/common/src/main/java/org/terracotta/angela/common/tcconfig/holders/TcConfigHolder.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/tms/security/config/TmsClientSecurityConfig.java
+++ b/common/src/main/java/org/terracotta/angela/common/tms/security/config/TmsClientSecurityConfig.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/tms/security/config/TmsServerSecurityConfig.java
+++ b/common/src/main/java/org/terracotta/angela/common/tms/security/config/TmsServerSecurityConfig.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/topology/ClientArrayTopology.java
+++ b/common/src/main/java/org/terracotta/angela/common/topology/ClientArrayTopology.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/topology/InstanceId.java
+++ b/common/src/main/java/org/terracotta/angela/common/topology/InstanceId.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/topology/LicenseType.java
+++ b/common/src/main/java/org/terracotta/angela/common/topology/LicenseType.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/topology/PackageType.java
+++ b/common/src/main/java/org/terracotta/angela/common/topology/PackageType.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/topology/TmsConfig.java
+++ b/common/src/main/java/org/terracotta/angela/common/topology/TmsConfig.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/topology/Topology.java
+++ b/common/src/main/java/org/terracotta/angela/common/topology/Topology.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/topology/Version.java
+++ b/common/src/main/java/org/terracotta/angela/common/topology/Version.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/util/ActivityTracker.java
+++ b/common/src/main/java/org/terracotta/angela/common/util/ActivityTracker.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/util/AngelaVersion.java
+++ b/common/src/main/java/org/terracotta/angela/common/util/AngelaVersion.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/util/AngelaVersions.java
+++ b/common/src/main/java/org/terracotta/angela/common/util/AngelaVersions.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/util/Cmd.java
+++ b/common/src/main/java/org/terracotta/angela/common/util/Cmd.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/util/ExternalLoggers.java
+++ b/common/src/main/java/org/terracotta/angela/common/util/ExternalLoggers.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/util/FileUtils.java
+++ b/common/src/main/java/org/terracotta/angela/common/util/FileUtils.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/util/HostAndIpValidator.java
+++ b/common/src/main/java/org/terracotta/angela/common/util/HostAndIpValidator.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/util/HostPort.java
+++ b/common/src/main/java/org/terracotta/angela/common/util/HostPort.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/util/IpUtils.java
+++ b/common/src/main/java/org/terracotta/angela/common/util/IpUtils.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/util/JDK.java
+++ b/common/src/main/java/org/terracotta/angela/common/util/JDK.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/util/JavaBinaries.java
+++ b/common/src/main/java/org/terracotta/angela/common/util/JavaBinaries.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/util/JavaLocationResolver.java
+++ b/common/src/main/java/org/terracotta/angela/common/util/JavaLocationResolver.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/util/Jcmd.java
+++ b/common/src/main/java/org/terracotta/angela/common/util/Jcmd.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/util/KitUtils.java
+++ b/common/src/main/java/org/terracotta/angela/common/util/KitUtils.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/util/LogOutputStream.java
+++ b/common/src/main/java/org/terracotta/angela/common/util/LogOutputStream.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/util/OS.java
+++ b/common/src/main/java/org/terracotta/angela/common/util/OS.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/util/ProcessUtil.java
+++ b/common/src/main/java/org/terracotta/angela/common/util/ProcessUtil.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/util/RetryUtils.java
+++ b/common/src/main/java/org/terracotta/angela/common/util/RetryUtils.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/util/TimeBudget.java
+++ b/common/src/main/java/org/terracotta/angela/common/util/TimeBudget.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/util/TriggeringOutputStream.java
+++ b/common/src/main/java/org/terracotta/angela/common/util/TriggeringOutputStream.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/java/org/terracotta/angela/common/util/UniversalPath.java
+++ b/common/src/main/java/org/terracotta/angela/common/util/UniversalPath.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/main/resources/META-INF/services/org.terracotta.angela.common.net.DisruptionProvider
+++ b/common/src/main/resources/META-INF/services/org.terracotta.angela.common.net.DisruptionProvider
@@ -1,18 +1,18 @@
 #
-# The contents of this file are subject to the Terracotta Public License Version
-# 2.0 (the "License"); You may not use this file except in compliance with the
-# License. You may obtain a copy of the License at
+# Copyright Terracotta, Inc.
+# Copyright Super iPaaS Integration LLC, an IBM Company 2024
 #
-# http://terracotta.org/legal/terracotta-public-license.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# Software distributed under the License is distributed on an "AS IS" basis,
-# WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-# the specific language governing rights and limitations under the License.
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
-# The Covered Software is Angela.
-#
-# The Initial Developer of the Covered Software is
-# Terracotta, Inc., a Software AG company
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 org.terracotta.angela.common.net.NetCrusherProvider

--- a/common/src/main/resources/angela/angela-version.properties
+++ b/common/src/main/resources/angela/angela-version.properties
@@ -1,18 +1,18 @@
 #
-# The contents of this file are subject to the Terracotta Public License Version
-# 2.0 (the "License"); You may not use this file except in compliance with the
-# License. You may obtain a copy of the License at
+# Copyright Terracotta, Inc.
+# Copyright Super iPaaS Integration LLC, an IBM Company 2024
 #
-# http://terracotta.org/legal/terracotta-public-license.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# Software distributed under the License is distributed on an "AS IS" basis,
-# WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-# the specific language governing rights and limitations under the License.
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
-# The Covered Software is Angela.
-#
-# The Initial Developer of the Covered Software is
-# Terracotta, Inc., a Software AG company
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 angela.version=${project.version}

--- a/common/src/main/resources/angela/versions.properties
+++ b/common/src/main/resources/angela/versions.properties
@@ -1,18 +1,18 @@
 #
-# The contents of this file are subject to the Terracotta Public License Version
-# 2.0 (the "License"); You may not use this file except in compliance with the
-# License. You may obtain a copy of the License at
+# Copyright Terracotta, Inc.
+# Copyright Super iPaaS Integration LLC, an IBM Company 2024
 #
-# http://terracotta.org/legal/terracotta-public-license.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# Software distributed under the License is distributed on an "AS IS" basis,
-# WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-# the specific language governing rights and limitations under the License.
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
-# The Covered Software is Angela.
-#
-# The Initial Developer of the Covered Software is
-# Terracotta, Inc., a Software AG company
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 angela.version=${pom.version}

--- a/common/src/main/resources/org/terracotta/angela/common/tcconfig/tsa-config-tc-config-template-10.xml
+++ b/common/src/main/resources/org/terracotta/angela/common/tcconfig/tsa-config-tc-config-template-10.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ The contents of this file are subject to the Terracotta Public License Version
-  ~ 2.0 (the "License"); You may not use this file except in compliance with the
-  ~ License. You may obtain a copy of the License at
+  ~ Copyright Terracotta, Inc.
+  ~ Copyright Super iPaaS Integration LLC, an IBM Company 2024
   ~
-  ~ http://terracotta.org/legal/terracotta-public-license.
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
   ~
-  ~ Software distributed under the License is distributed on an "AS IS" basis,
-  ~ WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  ~ the specific language governing rights and limitations under the License.
+  ~     http://www.apache.org/licenses/LICENSE-2.0
   ~
-  ~ The Covered Software is Angela.
-  ~
-  ~ The Initial Developer of the Covered Software is
-  ~ Terracotta, Inc., a Software AG company
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
   -->
 
 <tc-config xmlns="http://www.terracotta.org/config">

--- a/common/src/test/java/org/terracotta/angela/common/distribution/Distribution107ControllerTest.java
+++ b/common/src/test/java/org/terracotta/angela/common/distribution/Distribution107ControllerTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/org/terracotta/angela/common/tcconfig/SecurityRootDirectoryTest.java
+++ b/common/src/test/java/org/terracotta/angela/common/tcconfig/SecurityRootDirectoryTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/org/terracotta/angela/common/tcconfig/TsaConfigTest.java
+++ b/common/src/test/java/org/terracotta/angela/common/tcconfig/TsaConfigTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/org/terracotta/angela/common/tcconfig/holders/TcConfig10HolderTest.java
+++ b/common/src/test/java/org/terracotta/angela/common/tcconfig/holders/TcConfig10HolderTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/org/terracotta/angela/common/tcconfig/holders/TcConfigHolderTest.java
+++ b/common/src/test/java/org/terracotta/angela/common/tcconfig/holders/TcConfigHolderTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/org/terracotta/angela/common/tms/security/config/TmsServerSecurityConfigTest.java
+++ b/common/src/test/java/org/terracotta/angela/common/tms/security/config/TmsServerSecurityConfigTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/org/terracotta/angela/common/topology/VersionTest.java
+++ b/common/src/test/java/org/terracotta/angela/common/topology/VersionTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/org/terracotta/angela/common/util/ActivityTrackerTest.java
+++ b/common/src/test/java/org/terracotta/angela/common/util/ActivityTrackerTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/org/terracotta/angela/common/util/JavaLocationResolverTest.java
+++ b/common/src/test/java/org/terracotta/angela/common/util/JavaLocationResolverTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/org/terracotta/angela/common/util/RetryUtilsTest.java
+++ b/common/src/test/java/org/terracotta/angela/common/util/RetryUtilsTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/java/org/terracotta/angela/common/util/UniversalPathTest.java
+++ b/common/src/test/java/org/terracotta/angela/common/util/UniversalPathTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/common/src/test/resources/logback-test.xml
+++ b/common/src/test/resources/logback-test.xml
@@ -1,18 +1,18 @@
 <!--
-  ~ The contents of this file are subject to the Terracotta Public License Version
-  ~ 2.0 (the "License"); You may not use this file except in compliance with the
-  ~ License. You may obtain a copy of the License at
+  ~ Copyright Terracotta, Inc.
+  ~ Copyright Super iPaaS Integration LLC, an IBM Company 2024
   ~
-  ~ http://terracotta.org/legal/terracotta-public-license.
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
   ~
-  ~ Software distributed under the License is distributed on an "AS IS" basis,
-  ~ WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  ~ the specific language governing rights and limitations under the License.
+  ~     http://www.apache.org/licenses/LICENSE-2.0
   ~
-  ~ The Covered Software is Angela.
-  ~
-  ~ The Initial Developer of the Covered Software is
-  ~ Terracotta, Inc., a Software AG company
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
   -->
 
 <configuration>

--- a/common/src/test/resources/tc-config.xml
+++ b/common/src/test/resources/tc-config.xml
@@ -1,18 +1,18 @@
 <!--
-  ~ The contents of this file are subject to the Terracotta Public License Version
-  ~ 2.0 (the "License"); You may not use this file except in compliance with the
-  ~ License. You may obtain a copy of the License at
+  ~ Copyright Terracotta, Inc.
+  ~ Copyright Super iPaaS Integration LLC, an IBM Company 2024
   ~
-  ~ http://terracotta.org/legal/terracotta-public-license.
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
   ~
-  ~ Software distributed under the License is distributed on an "AS IS" basis,
-  ~ WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  ~ the specific language governing rights and limitations under the License.
+  ~     http://www.apache.org/licenses/LICENSE-2.0
   ~
-  ~ The Covered Software is Angela.
-  ~
-  ~ The Initial Developer of the Covered Software is
-  ~ Terracotta, Inc., a Software AG company
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
   -->
 
 <tc-config xmlns="http://www.terracotta.org/config">

--- a/common/src/test/resources/toolchains/toolchains.xml
+++ b/common/src/test/resources/toolchains/toolchains.xml
@@ -1,18 +1,18 @@
 <!--
-  ~ The contents of this file are subject to the Terracotta Public License Version
-  ~ 2.0 (the "License"); You may not use this file except in compliance with the
-  ~ License. You may obtain a copy of the License at
+  ~ Copyright Terracotta, Inc.
+  ~ Copyright Super iPaaS Integration LLC, an IBM Company 2024
   ~
-  ~ http://terracotta.org/legal/terracotta-public-license.
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
   ~
-  ~ Software distributed under the License is distributed on an "AS IS" basis,
-  ~ WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  ~ the specific language governing rights and limitations under the License.
+  ~     http://www.apache.org/licenses/LICENSE-2.0
   ~
-  ~ The Covered Software is Angela.
-  ~
-  ~ The Initial Developer of the Covered Software is
-  ~ Terracotta, Inc., a Software AG company
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
   -->
 
 <toolchains>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ The contents of this file are subject to the Terracotta Public License Version
-  ~ 2.0 (the "License"); You may not use this file except in compliance with the
-  ~ License. You may obtain a copy of the License at
+  ~ Copyright Terracotta, Inc.
+  ~ Copyright Super iPaaS Integration LLC, an IBM Company 2024
   ~
-  ~ http://terracotta.org/legal/terracotta-public-license.
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
   ~
-  ~ Software distributed under the License is distributed on an "AS IS" basis,
-  ~ WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  ~ the specific language governing rights and limitations under the License.
+  ~     http://www.apache.org/licenses/LICENSE-2.0
   ~
-  ~ The Covered Software is Angela.
-  ~
-  ~ The Initial Developer of the Covered Software is
-  ~ Terracotta, Inc., a Software AG company
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"

--- a/docs/src/main/java/GettingStarted.java
+++ b/docs/src/main/java/GettingStarted.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/src/main/resources/logback.xml
+++ b/docs/src/main/resources/logback.xml
@@ -1,18 +1,18 @@
 <!--
-  ~ The contents of this file are subject to the Terracotta Public License Version
-  ~ 2.0 (the "License"); You may not use this file except in compliance with the
-  ~ License. You may obtain a copy of the License at
+  ~ Copyright Terracotta, Inc.
+  ~ Copyright Super iPaaS Integration LLC, an IBM Company 2024
   ~
-  ~ http://terracotta.org/legal/terracotta-public-license.
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
   ~
-  ~ Software distributed under the License is distributed on an "AS IS" basis,
-  ~ WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  ~ the specific language governing rights and limitations under the License.
+  ~     http://www.apache.org/licenses/LICENSE-2.0
   ~
-  ~ The Covered Software is Angela.
-  ~
-  ~ The Initial Developer of the Covered Software is
-  ~ Terracotta, Inc., a Software AG company
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
   -->
 
 <configuration>

--- a/docs/src/main/resources/tc-config-a.xml
+++ b/docs/src/main/resources/tc-config-a.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ The contents of this file are subject to the Terracotta Public License Version
-  ~ 2.0 (the "License"); You may not use this file except in compliance with the
-  ~ License. You may obtain a copy of the License at
+  ~ Copyright Terracotta, Inc.
+  ~ Copyright Super iPaaS Integration LLC, an IBM Company 2024
   ~
-  ~ http://terracotta.org/legal/terracotta-public-license.
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
   ~
-  ~ Software distributed under the License is distributed on an "AS IS" basis,
-  ~ WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  ~ the specific language governing rights and limitations under the License.
+  ~     http://www.apache.org/licenses/LICENSE-2.0
   ~
-  ~ The Covered Software is Angela.
-  ~
-  ~ The Initial Developer of the Covered Software is
-  ~ Terracotta, Inc., a Software AG company
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
   -->
 
 <tc-config xmlns="http://www.terracotta.org/config">

--- a/docs/src/main/resources/tc-config-ap.xml
+++ b/docs/src/main/resources/tc-config-ap.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ The contents of this file are subject to the Terracotta Public License Version
-  ~ 2.0 (the "License"); You may not use this file except in compliance with the
-  ~ License. You may obtain a copy of the License at
+  ~ Copyright Terracotta, Inc.
+  ~ Copyright Super iPaaS Integration LLC, an IBM Company 2024
   ~
-  ~ http://terracotta.org/legal/terracotta-public-license.
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
   ~
-  ~ Software distributed under the License is distributed on an "AS IS" basis,
-  ~ WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  ~ the specific language governing rights and limitations under the License.
+  ~     http://www.apache.org/licenses/LICENSE-2.0
   ~
-  ~ The Covered Software is Angela.
-  ~
-  ~ The Initial Developer of the Covered Software is
-  ~ Terracotta, Inc., a Software AG company
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
   -->
 
 <tc-config xmlns="http://www.terracotta.org/config">

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ The contents of this file are subject to the Terracotta Public License Version
-  ~ 2.0 (the "License"); You may not use this file except in compliance with the
-  ~ License. You may obtain a copy of the License at
+  ~ Copyright Terracotta, Inc.
+  ~ Copyright Super iPaaS Integration LLC, an IBM Company 2024
   ~
-  ~ http://terracotta.org/legal/terracotta-public-license.
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
   ~
-  ~ Software distributed under the License is distributed on an "AS IS" basis,
-  ~ WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  ~ the specific language governing rights and limitations under the License.
+  ~     http://www.apache.org/licenses/LICENSE-2.0
   ~
-  ~ The Covered Software is Angela.
-  ~
-  ~ The Initial Developer of the Covered Software is
-  ~ Terracotta, Inc., a Software AG company
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"

--- a/integration-test/src/test/java/org/terracotta/angela/AngelaRuleIT.java
+++ b/integration-test/src/test/java/org/terracotta/angela/AngelaRuleIT.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-test/src/test/java/org/terracotta/angela/BaseIT.java
+++ b/integration-test/src/test/java/org/terracotta/angela/BaseIT.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-test/src/test/java/org/terracotta/angela/BrowseIT.java
+++ b/integration-test/src/test/java/org/terracotta/angela/BrowseIT.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-test/src/test/java/org/terracotta/angela/ClientIT.java
+++ b/integration-test/src/test/java/org/terracotta/angela/ClientIT.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-test/src/test/java/org/terracotta/angela/ConfigToolIT.java
+++ b/integration-test/src/test/java/org/terracotta/angela/ConfigToolIT.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-test/src/test/java/org/terracotta/angela/DynamicClusterIT.java
+++ b/integration-test/src/test/java/org/terracotta/angela/DynamicClusterIT.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-test/src/test/java/org/terracotta/angela/EhcacheIT.java
+++ b/integration-test/src/test/java/org/terracotta/angela/EhcacheIT.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-test/src/test/java/org/terracotta/angela/InstallIT.java
+++ b/integration-test/src/test/java/org/terracotta/angela/InstallIT.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-test/src/test/java/org/terracotta/angela/MultiServerIT.java
+++ b/integration-test/src/test/java/org/terracotta/angela/MultiServerIT.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-test/src/test/java/org/terracotta/angela/VoterIT.java
+++ b/integration-test/src/test/java/org/terracotta/angela/VoterIT.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-test/src/test/java/org/terracotta/angela/agent/AgentIT.java
+++ b/integration-test/src/test/java/org/terracotta/angela/agent/AgentIT.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-test/src/test/java/org/terracotta/angela/agent/client/RemoteClientManagerIT.java
+++ b/integration-test/src/test/java/org/terracotta/angela/agent/client/RemoteClientManagerIT.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-test/src/test/java/org/terracotta/angela/agent/com/AgentGroupIT.java
+++ b/integration-test/src/test/java/org/terracotta/angela/agent/com/AgentGroupIT.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-test/src/test/java/org/terracotta/angela/agent/com/IgniteFreeExecutorIT.java
+++ b/integration-test/src/test/java/org/terracotta/angela/agent/com/IgniteFreeExecutorIT.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-test/src/test/java/org/terracotta/angela/agent/com/IgniteLocalExecutorIT.java
+++ b/integration-test/src/test/java/org/terracotta/angela/agent/com/IgniteLocalExecutorIT.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-test/src/test/java/org/terracotta/angela/agent/com/IgniteSshRemoteExecutorIT.java
+++ b/integration-test/src/test/java/org/terracotta/angela/agent/com/IgniteSshRemoteExecutorIT.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-test/src/test/java/org/terracotta/angela/util/SshServer.java
+++ b/integration-test/src/test/java/org/terracotta/angela/util/SshServer.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-test/src/test/java/org/terracotta/angela/util/TestUtils.java
+++ b/integration-test/src/test/java/org/terracotta/angela/util/TestUtils.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-test/src/test/java/org/terracotta/angela/util/Versions.java
+++ b/integration-test/src/test/java/org/terracotta/angela/util/Versions.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/integration-test/src/test/resources/configs/tc-config-a-short-lease.xml
+++ b/integration-test/src/test/resources/configs/tc-config-a-short-lease.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ The contents of this file are subject to the Terracotta Public License Version
-  ~ 2.0 (the "License"); You may not use this file except in compliance with the
-  ~ License. You may obtain a copy of the License at
+  ~ Copyright Terracotta, Inc.
+  ~ Copyright Super iPaaS Integration LLC, an IBM Company 2024
   ~
-  ~ http://terracotta.org/legal/terracotta-public-license.
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
   ~
-  ~ Software distributed under the License is distributed on an "AS IS" basis,
-  ~ WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  ~ the specific language governing rights and limitations under the License.
+  ~     http://www.apache.org/licenses/LICENSE-2.0
   ~
-  ~ The Covered Software is Angela.
-  ~
-  ~ The Initial Developer of the Covered Software is
-  ~ Terracotta, Inc., a Software AG company
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
   -->
 
 <tc-config xmlns="http://www.terracotta.org/config"

--- a/integration-test/src/test/resources/configs/tc-config-a.xml
+++ b/integration-test/src/test/resources/configs/tc-config-a.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ The contents of this file are subject to the Terracotta Public License Version
-  ~ 2.0 (the "License"); You may not use this file except in compliance with the
-  ~ License. You may obtain a copy of the License at
+  ~ Copyright Terracotta, Inc.
+  ~ Copyright Super iPaaS Integration LLC, an IBM Company 2024
   ~
-  ~ http://terracotta.org/legal/terracotta-public-license.
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
   ~
-  ~ Software distributed under the License is distributed on an "AS IS" basis,
-  ~ WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  ~ the specific language governing rights and limitations under the License.
+  ~     http://www.apache.org/licenses/LICENSE-2.0
   ~
-  ~ The Covered Software is Angela.
-  ~
-  ~ The Initial Developer of the Covered Software is
-  ~ Terracotta, Inc., a Software AG company
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
   -->
 
 <tc-config xmlns="http://www.terracotta.org/config"

--- a/integration-test/src/test/resources/configs/tc-config-ap-consistent.xml
+++ b/integration-test/src/test/resources/configs/tc-config-ap-consistent.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ The contents of this file are subject to the Terracotta Public License Version
-  ~ 2.0 (the "License"); You may not use this file except in compliance with the
-  ~ License. You may obtain a copy of the License at
+  ~ Copyright Terracotta, Inc.
+  ~ Copyright Super iPaaS Integration LLC, an IBM Company 2024
   ~
-  ~ http://terracotta.org/legal/terracotta-public-license.
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
   ~
-  ~ Software distributed under the License is distributed on an "AS IS" basis,
-  ~ WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  ~ the specific language governing rights and limitations under the License.
+  ~     http://www.apache.org/licenses/LICENSE-2.0
   ~
-  ~ The Covered Software is Angela.
-  ~
-  ~ The Initial Developer of the Covered Software is
-  ~ Terracotta, Inc., a Software AG company
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
   -->
 
 <tc-config xmlns="http://www.terracotta.org/config">

--- a/integration-test/src/test/resources/configs/tc-config-ap.xml
+++ b/integration-test/src/test/resources/configs/tc-config-ap.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ The contents of this file are subject to the Terracotta Public License Version
-  ~ 2.0 (the "License"); You may not use this file except in compliance with the
-  ~ License. You may obtain a copy of the License at
+  ~ Copyright Terracotta, Inc.
+  ~ Copyright Super iPaaS Integration LLC, an IBM Company 2024
   ~
-  ~ http://terracotta.org/legal/terracotta-public-license.
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
   ~
-  ~ Software distributed under the License is distributed on an "AS IS" basis,
-  ~ WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  ~ the specific language governing rights and limitations under the License.
+  ~     http://www.apache.org/licenses/LICENSE-2.0
   ~
-  ~ The Covered Software is Angela.
-  ~
-  ~ The Initial Developer of the Covered Software is
-  ~ Terracotta, Inc., a Software AG company
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
   -->
 
 <tc-config xmlns="http://www.terracotta.org/config">

--- a/integration-test/src/test/resources/configs/tc-config-app-consistent.xml
+++ b/integration-test/src/test/resources/configs/tc-config-app-consistent.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ The contents of this file are subject to the Terracotta Public License Version
-  ~ 2.0 (the "License"); You may not use this file except in compliance with the
-  ~ License. You may obtain a copy of the License at
+  ~ Copyright Terracotta, Inc.
+  ~ Copyright Super iPaaS Integration LLC, an IBM Company 2024
   ~
-  ~ http://terracotta.org/legal/terracotta-public-license.
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
   ~
-  ~ Software distributed under the License is distributed on an "AS IS" basis,
-  ~ WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  ~ the specific language governing rights and limitations under the License.
+  ~     http://www.apache.org/licenses/LICENSE-2.0
   ~
-  ~ The Covered Software is Angela.
-  ~
-  ~ The Initial Developer of the Covered Software is
-  ~ Terracotta, Inc., a Software AG company
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
   -->
 
 <tc-config xmlns="http://www.terracotta.org/config">

--- a/integration-test/src/test/resources/logback-test.xml
+++ b/integration-test/src/test/resources/logback-test.xml
@@ -1,18 +1,18 @@
 <!--
-  ~ The contents of this file are subject to the Terracotta Public License Version
-  ~ 2.0 (the "License"); You may not use this file except in compliance with the
-  ~ License. You may obtain a copy of the License at
+  ~ Copyright Terracotta, Inc.
+  ~ Copyright Super iPaaS Integration LLC, an IBM Company 2024
   ~
-  ~ http://terracotta.org/legal/terracotta-public-license.
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
   ~
-  ~ Software distributed under the License is distributed on an "AS IS" basis,
-  ~ WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  ~ the specific language governing rights and limitations under the License.
+  ~     http://www.apache.org/licenses/LICENSE-2.0
   ~
-  ~ The Covered Software is Angela.
-  ~
-  ~ The Initial Developer of the Covered Software is
-  ~ Terracotta, Inc., a Software AG company
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
   -->
 
 <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ The contents of this file are subject to the Terracotta Public License Version
-  ~ 2.0 (the "License"); You may not use this file except in compliance with the
-  ~ License. You may obtain a copy of the License at
+  ~ Copyright Terracotta, Inc.
+  ~ Copyright Super iPaaS Integration LLC, an IBM Company 2024
   ~
-  ~ http://terracotta.org/legal/terracotta-public-license.
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
   ~
-  ~ Software distributed under the License is distributed on an "AS IS" basis,
-  ~ WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
-  ~ the specific language governing rights and limitations under the License.
+  ~     http://www.apache.org/licenses/LICENSE-2.0
   ~
-  ~ The Covered Software is Angela.
-  ~
-  ~ The Initial Developer of the Covered Software is
-  ~ Terracotta, Inc., a Software AG company
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.terracotta</groupId>
     <artifactId>terracotta-parent</artifactId>
-    <version>5.21</version>
+    <version>5.23</version>
   </parent>
 
   <artifactId>angela-root</artifactId>
@@ -470,39 +470,9 @@
 
   <developers>
     <developer>
-      <name>Aurelien Broszniowski</name>
-      <organization>Terracotta Inc., a wholly-owned subsidiary of Software AG USA, Inc.</organization>
+      <name>Terracotta Developers</name>
+      <email>tc-oss-dg@ibm.com</email>
+      <organization>Super iPaaS Integration LLC, an IBM Company</organization>
       <organizationUrl>https://terracotta.org</organizationUrl>
     </developer>
-    <developer>
-      <name>Saurabh Agarwal</name>
-      <organization>Terracotta Inc., a wholly-owned subsidiary of Software AG USA, Inc.</organization>
-      <organizationUrl>https://terracotta.org</organizationUrl>
-    </developer>
-    <developer>
-      <name>Alexander Komarov</name>
-      <organization>Terracotta Inc., a wholly-owned subsidiary of Software AG USA, Inc.</organization>
-      <organizationUrl>https://terracotta.org</organizationUrl>
-    </developer>
-    <developer>
-      <name>Albin Suresh</name>
-      <organization>Terracotta Inc., a wholly-owned subsidiary of Software AG USA, Inc.</organization>
-      <organizationUrl>https://terracotta.org</organizationUrl>
-    </developer>
-    <developer>
-      <name>Chris Dennis</name>
-      <organization>Terracotta Inc., a wholly-owned subsidiary of Software AG USA, Inc.</organization>
-      <organizationUrl>https://terracotta.org</organizationUrl>
-    </developer>
-    <developer>
-      <name>Md Mobasherul Haque</name>
-      <organization>Terracotta Inc., a wholly-owned subsidiary of Software AG USA, Inc.</organization>
-      <organizationUrl>https://terracotta.org</organizationUrl>
-    </developer>
-    <developer>
-      <name>Venkata Sairam Madduri</name>
-      <organization>Terracotta Inc., a wholly-owned subsidiary of Software AG USA, Inc.</organization>
-      <organizationUrl>https://terracotta.org</organizationUrl>
-    </developer>
-  </developers>
-</project>
+  </developers></project>

--- a/settings.xml
+++ b/settings.xml
@@ -2,6 +2,7 @@
 <!--
 
     Copyright Terracotta, Inc.
+    Copyright Super iPaaS Integration LLC, an IBM Company 2024
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
IBM copyright added; TPL licenses changed to ASL2; normalizes the `developers` section of the POM; and updates the terracotta-parent used to 5.23.