### PR TITLE
Correct failures in ClientIT for igniteLocal()

### DIFF
--- a/agent-lib/src/main/java/org/terracotta/angela/agent/Agent.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/agent/Agent.java
@@ -76,6 +76,7 @@ public class Agent implements AutoCloseable {
 
     ROOT_DIR = Paths.get(getEitherOf(AngelaProperties.ROOT_DIR, AngelaProperties.KITS_DIR));
     if (!ROOT_DIR.isAbsolute()) {
+      logger.error("Expected ROOT_DIR to be an absolute path, got: {}", ROOT_DIR);
       throw new IllegalArgumentException("Expected ROOT_DIR to be an absolute path, got: " + ROOT_DIR);
     }
     WORK_DIR = ROOT_DIR.resolve("work");
@@ -126,11 +127,13 @@ public class Agent implements AutoCloseable {
   public static void main(String[] args) {
     final String instanceName = System.getProperty("angela.instanceName");
     if (instanceName == null) {
+      logger.error("angela.instanceName is missing");
       throw new AssertionError("angela.instanceName is missing");
     }
 
     final String group = System.getProperty("angela.group");
     if (group == null) {
+      logger.error("angela.group is missing");
       throw new AssertionError("angela.group is missing");
     }
 
@@ -247,6 +250,7 @@ public class Agent implements AutoCloseable {
     try {
       ignite = Ignition.start(cfg);
     } catch (IgniteException e) {
+      logger.error("Error starting node {}", cfg, e);
       throw new RuntimeException("Error starting node " + agentID, e);
     }
 

--- a/agent-lib/src/main/java/org/terracotta/angela/agent/AgentController.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/agent/AgentController.java
@@ -571,6 +571,7 @@ public class AgentController {
         ProcessUtil.destroyGracefullyOrForcefullyAndWait(pid);
       }
     } catch (Exception e) {
+      logger.error("Error stopping client {}", instanceId, e);
       throw new RuntimeException("Error stopping client " + instanceId, e);
     }
   }
@@ -578,7 +579,12 @@ public class AgentController {
   public void deleteClient(InstanceId instanceId) {
     Path subAgentRoot = new RemoteClientManager(instanceId).getClientInstallationPath();
     logger.debug("[{}] Cleaning up directory structure '{}' of client {}", localAgentID, subAgentRoot, instanceId);
-    FileUtils.deleteTree(subAgentRoot);
+    try {
+      FileUtils.deleteTree(subAgentRoot);
+      logger.debug("[{}] Completed cleanup of directory structure '{}' of client {}", localAgentID, subAgentRoot, instanceId);
+    } catch (UncheckedIOException e) {
+      logger.warn("Failed to deleteTree \"{}\"", subAgentRoot, e);
+    }
   }
 
   public String instanceWorkDir(InstanceId instanceId) {

--- a/agent-lib/src/main/java/org/terracotta/angela/agent/com/IgniteLocalExecutor.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/agent/com/IgniteLocalExecutor.java
@@ -32,6 +32,7 @@ import org.terracotta.angela.common.topology.InstanceId;
 import org.terracotta.angela.common.util.IpUtils;
 
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -79,8 +80,9 @@ public class IgniteLocalExecutor implements Executor {
         .filter(Optional::isPresent)
         .map(Optional::get)
         .toArray(CompletableFuture[]::new));
+    Duration timeout = Duration.ofSeconds(30L);
     try {
-      future.get(20, TimeUnit.SECONDS);
+      future.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new RuntimeException(e);
@@ -88,7 +90,7 @@ public class IgniteLocalExecutor implements Executor {
       // impossible to go there
       throw new AssertionError(e.getCause());
     } catch (TimeoutException e) {
-      logger.warn("Some agents did not shutdown within 20 seconds: {}", agentGroup.getSpawnedAgents(), e);
+      logger.warn("Some agents did not shutdown within {}: {}", timeout, agentGroup.getSpawnedAgents(), e);
     }
   }
 

--- a/integration-test/src/test/java/org/terracotta/angela/ClientIT.java
+++ b/integration-test/src/test/java/org/terracotta/angela/ClientIT.java
@@ -16,7 +16,6 @@
  */
 package org.terracotta.angela;
 
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.terracotta.angela.client.Client;
 import org.terracotta.angela.client.ClientArray;
@@ -51,7 +50,6 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
@@ -78,13 +76,6 @@ import static org.terracotta.angela.common.topology.Version.version;
 import static org.terracotta.angela.util.TestUtils.TC_CONFIG_A;
 
 public class ClientIT extends BaseIT {
-  
-  @BeforeClass
-  public static void failsOnWindows() {
-    System.out.format("os.name=%s; java.version=%s%n", System.getProperty("os.name"), System.getProperty("java.version"));
-    boolean isWindows = System.getProperty("os.name", "").toLowerCase(Locale.ROOT).startsWith("win");
-    assumeFalse("Client classpath issues on Windows", isWindows);
-  }
 
   public ClientIT(String mode, String hostname, boolean inline, boolean ssh) {
     super(mode, hostname, inline, ssh);


### PR DESCRIPTION
This commit adds some failure logging, corrects the classpath built by RemoteClientManager.buildClasspath, and changes Client.stop to remove the client AgentID from the AgentGroup after killing the client.