### PR TITLE
KitInstallationPath fixes

### DIFF
--- a/client-internal/src/main/java/org/terracotta/angela/client/ClusterTool.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/ClusterTool.java
@@ -115,15 +115,19 @@ public class ClusterTool implements AutoCloseable {
 
     logger.info("Installing config-tool: {} on: {}", instanceId, executor.getTarget());
     final InstanceId localInstanceId = instanceId;
-    RemoteCallable<Boolean> callable = () -> AgentController.getInstance().installClusterTool(localInstanceId, hostName, distribution, license, kitInstallationName, securityRootDirectory, tcEnv, kitInstallationPath);
-    boolean isRemoteInstallationSuccessful = executor.execute(callable);
-    if (!isRemoteInstallationSuccessful && (kitInstallationPath == null || !KIT_COPY.getBooleanValue())) {
-      try {
-        executor.uploadKit(instanceId, distribution, kitInstallationName, localKitManager.getKitInstallationPath());
-        executor.execute(callable);
-      } catch (Exception e) {
-        throw new RuntimeException("Cannot upload kit to " + hostName, e);
+    if (kitInstallationPath == null || KIT_COPY.getBooleanValue()) {
+      RemoteCallable<Boolean> callable = () -> AgentController.getInstance().installClusterTool(localInstanceId, hostName, distribution, license, kitInstallationName, securityRootDirectory, tcEnv, null);
+      boolean isRemoteInstallationSuccessful = executor.execute(callable);
+      if (!isRemoteInstallationSuccessful) {
+        try {
+          executor.uploadKit(instanceId, distribution, kitInstallationName, localKitManager.getKitInstallationPath());
+          executor.execute(callable);
+        } catch (Exception e) {
+          throw new RuntimeException("Cannot upload kit to " + hostName, e);
+        }
       }
+    } else {
+      executor.execute(() -> AgentController.getInstance().installClusterTool(localInstanceId, hostName, distribution, license, kitInstallationName, securityRootDirectory, tcEnv, kitInstallationPath));
     }
     return this;
   }

--- a/client-internal/src/main/java/org/terracotta/angela/client/ConfigTool.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/ConfigTool.java
@@ -422,15 +422,19 @@ public class ConfigTool implements AutoCloseable {
     final String hostName = configContext.getHostName();
     final String kitInstallationName = localKitManager.getKitInstallationName();
     final InstanceId localInstanceId = instanceId;
-    final RemoteCallable<Boolean> callable = () -> AgentController.getInstance().installConfigTool(localInstanceId, hostName, distribution, license, kitInstallationName, securityRootDirectory, tcEnv, kitInstallationPath);
-    boolean isRemoteInstallationSuccessful = executor.execute(callable);
-    if (!isRemoteInstallationSuccessful && (kitInstallationPath == null || !KIT_COPY.getBooleanValue())) {
-      try {
-        executor.uploadKit(instanceId, distribution, kitInstallationName, localKitManager.getKitInstallationPath());
-        executor.execute(callable);
-      } catch (Exception e) {
-        throw new RuntimeException("Cannot upload kit to " + hostName, e);
+    if (kitInstallationPath == null || KIT_COPY.getBooleanValue()) {
+      final RemoteCallable<Boolean> callable = () -> AgentController.getInstance().installConfigTool(localInstanceId, hostName, distribution, license, kitInstallationName, securityRootDirectory, tcEnv, null);
+      boolean isRemoteInstallationSuccessful = executor.execute(callable);
+      if (!isRemoteInstallationSuccessful) {
+        try {
+          executor.uploadKit(instanceId, distribution, kitInstallationName, localKitManager.getKitInstallationPath());
+          executor.execute(callable);
+        } catch (Exception e) {
+          throw new RuntimeException("Cannot upload kit to " + hostName, e);
+        }
       }
+    } else {
+      executor.execute(() -> AgentController.getInstance().installConfigTool(localInstanceId, hostName, distribution, license, kitInstallationName, securityRootDirectory, tcEnv, kitInstallationPath));
     }
     return this;
   }

--- a/client-internal/src/main/java/org/terracotta/angela/client/RestoreTool.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/RestoreTool.java
@@ -88,15 +88,19 @@ public class RestoreTool implements AutoCloseable {
     logger.info("Installing restore-tool: {} on: {}", instanceId, executor.getTarget());
 
     final InstanceId localInstanceId = instanceId;
-    RemoteCallable<Boolean> callable = () -> AgentController.getInstance().installRestoreTool(localInstanceId, hostName, distribution, license, kitInstallationName, securityRootDirectory, tcEnv, kitInstallationPath);
-    boolean isRemoteInstallationSuccessful = executor.execute(callable);
-    if (!isRemoteInstallationSuccessful && (kitInstallationPath == null || !KIT_COPY.getBooleanValue())) {
-      try {
-        executor.uploadKit(instanceId, distribution, kitInstallationName, localKitManager.getKitInstallationPath());
-        executor.execute(callable);
-      } catch (Exception e) {
-        throw new RuntimeException("Cannot upload kit to " + hostName, e);
+    if (kitInstallationPath == null || KIT_COPY.getBooleanValue()) {
+      RemoteCallable<Boolean> callable = () -> AgentController.getInstance().installRestoreTool(localInstanceId, hostName, distribution, license, kitInstallationName, securityRootDirectory, tcEnv, null);
+      boolean isRemoteInstallationSuccessful = executor.execute(callable);
+      if (!isRemoteInstallationSuccessful) {
+        try {
+          executor.uploadKit(instanceId, distribution, kitInstallationName, localKitManager.getKitInstallationPath());
+          executor.execute(callable);
+        } catch (Exception e) {
+          throw new RuntimeException("Cannot upload kit to " + hostName, e);
+        }
       }
+    } else {
+      executor.execute(() -> AgentController.getInstance().installRestoreTool(localInstanceId, hostName, distribution, license, kitInstallationName, securityRootDirectory, tcEnv, kitInstallationPath));
     }
     return this;
   }

--- a/client-internal/src/main/java/org/terracotta/angela/client/Tms.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/Tms.java
@@ -40,6 +40,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.function.Supplier;
 
+import static org.terracotta.angela.common.AngelaProperties.KIT_COPY;
 import static org.terracotta.angela.common.AngelaProperties.KIT_INSTALLATION_DIR;
 import static org.terracotta.angela.common.AngelaProperties.KIT_INSTALLATION_PATH;
 import static org.terracotta.angela.common.AngelaProperties.OFFLINE;
@@ -190,16 +191,19 @@ public class Tms implements AutoCloseable {
     final String kitInstallationName = localKitManager.getKitInstallationName();
 
     final InstanceId localInstanceId = instanceId;
-    RemoteCallable<Boolean> callable = () -> AgentController.getInstance().installTms(localInstanceId, tmsHostname, distribution, license, tmsServerSecurityConfig, kitInstallationName, tcEnv, tmsHostname, kitInstallationPath);
-    boolean isRemoteInstallationSuccessful = executor.execute(agentID, callable);
-
-    if (!isRemoteInstallationSuccessful) {
-      try {
-        executor.uploadKit(agentID, instanceId, distribution, kitInstallationName, localKitManager.getKitInstallationPath());
-        executor.execute(agentID, callable);
-      } catch (Exception e) {
-        throw new RuntimeException("Cannot upload kit to " + tmsHostname, e);
+    if (kitInstallationPath == null || KIT_COPY.getBooleanValue()) {
+      RemoteCallable<Boolean> callable = () -> AgentController.getInstance().installTms(localInstanceId, tmsHostname, distribution, license, tmsServerSecurityConfig, kitInstallationName, tcEnv, tmsHostname, null);
+      boolean isRemoteInstallationSuccessful = executor.execute(agentID, callable);
+      if (!isRemoteInstallationSuccessful) {
+        try {
+          executor.uploadKit(agentID, instanceId, distribution, kitInstallationName, localKitManager.getKitInstallationPath());
+          executor.execute(agentID, callable);
+        } catch (Exception e) {
+          throw new RuntimeException("Cannot upload kit to " + tmsHostname, e);
+        }
       }
+    } else {
+      executor.execute(agentID, () -> AgentController.getInstance().installTms(localInstanceId, tmsHostname, distribution, license, tmsServerSecurityConfig, kitInstallationName, tcEnv, tmsHostname, kitInstallationPath));
     }
 
   }

--- a/client-internal/src/main/java/org/terracotta/angela/client/Tsa.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/Tsa.java
@@ -32,6 +32,7 @@ import org.terracotta.angela.common.TerracottaCommandLineEnvironment;
 import org.terracotta.angela.common.TerracottaServerState;
 import org.terracotta.angela.common.distribution.Distribution;
 import org.terracotta.angela.common.net.PortAllocator;
+import org.terracotta.angela.common.util.IpUtils;
 import org.terracotta.angela.common.provider.ConfigurationManager;
 import org.terracotta.angela.common.provider.TcConfigManager;
 import org.terracotta.angela.common.tcconfig.License;
@@ -174,6 +175,11 @@ public class Tsa implements AutoCloseable {
     } else {
       // We are trying to reuse the "kitInstallationPath" if provided (kitInstallationPath != null)
       // To end up here, KIT_COPY should be false
+      if (!IpUtils.areAllLocal(Collections.singleton(terracottaServer.getHostName()))) {
+        logger.warn("kitInstallationPath is set to '{}' but kitCopy is false: Angela will NOT upload the kit to remote host '{}'. " +
+            "The kit must already be present at that exact path on the remote host, or the installation will fail. " +
+            "Set -DkitCopy=true to have Angela copy the kit automatically.", kitInstallationPath, terracottaServer.getHostName());
+      }
       executor.execute(agentID, () -> AgentController.getInstance().installTsa(localInstanceId, terracottaServer, license, kitInstallationName, distribution, topology, kitInstallationPath));
     }
   }

--- a/client-internal/src/main/java/org/terracotta/angela/client/Voter.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/Voter.java
@@ -161,18 +161,21 @@ public class Voter implements AutoCloseable {
     final String kitInstallationName = localKitManager.getKitInstallationName();
 
     final InstanceId localInstanceId = instanceId;
-    RemoteCallable<Boolean> callable = () -> AgentController.getInstance().installVoter(localInstanceId, terracottaVoter, distribution, license, kitInstallationName, securityRootDirectory, tcEnv, kitInstallationPath);
-
     logger.info("Installing Voter: {} on: {}", instanceId, agentID);
 
-    boolean isRemoteInstallationSuccessful = executor.execute(agentID, callable);
-    if (!isRemoteInstallationSuccessful && (kitInstallationPath == null || !KIT_COPY.getBooleanValue())) {
-      try {
-        executor.uploadKit(agentID, instanceId, distribution, kitInstallationName, localKitManager.getKitInstallationPath());
-        executor.execute(agentID, callable);
-      } catch (Exception e) {
-        throw new RuntimeException("Cannot upload kit to " + terracottaVoter.getHostName(), e);
+    if (kitInstallationPath == null || KIT_COPY.getBooleanValue()) {
+      RemoteCallable<Boolean> callable = () -> AgentController.getInstance().installVoter(localInstanceId, terracottaVoter, distribution, license, kitInstallationName, securityRootDirectory, tcEnv, null);
+      boolean isRemoteInstallationSuccessful = executor.execute(agentID, callable);
+      if (!isRemoteInstallationSuccessful) {
+        try {
+          executor.uploadKit(agentID, instanceId, distribution, kitInstallationName, localKitManager.getKitInstallationPath());
+          executor.execute(agentID, callable);
+        } catch (Exception e) {
+          throw new RuntimeException("Cannot upload kit to " + terracottaVoter.getHostName(), e);
+        }
       }
+    } else {
+      executor.execute(agentID, () -> AgentController.getInstance().installVoter(localInstanceId, terracottaVoter, distribution, license, kitInstallationName, securityRootDirectory, tcEnv, kitInstallationPath));
     }
   }
 

--- a/common/src/main/java/org/terracotta/angela/common/metrics/HardwareMetric.java
+++ b/common/src/main/java/org/terracotta/angela/common/metrics/HardwareMetric.java
@@ -19,8 +19,6 @@ package org.terracotta.angela.common.metrics;
 public enum HardwareMetric {
 
     CPU(new MonitoringCommand("mpstat",
-        "-P", // Specify the processors
-        "ALL", // Specify ALL processors - duh!
         "10")),
     DISK(new MonitoringCommand( "iostat",
         "-h", // Human-readable output


### PR DESCRIPTION
The kitInstallationPath property goal is to allow a developer to use his custom local Terracotta kit build instead of having Angela downloading a kit from Kratos.
However there were two issues when using Angela to use such a local custom kit for a remote test:
 - A condition would skip the copy to the remote host
 - If the user doesn't set angela.kitcopy=true, Angela doesn't copy the kit to the remote host, and expects the developer to deploy himself the kit (there could be some case where the dev wants to deploy himself the kit). However there would be no warning and if the kit wasn't deployed, it would fail. Some warning now exists to explain the expectation to the developer.

Another fix was added : Do not monitor all CPU cores with mpstat to avoid a huge cpu log
