### PR TITLE
Proxy disruptor

### DIFF
--- a/agent-lib/pom.xml
+++ b/agent-lib/pom.xml
@@ -62,6 +62,19 @@
       <version>1.0.1</version>
     </dependency>
 
+    <!--
+      Bundled as a classpath resource (not a transitive Java dependency)
+      via maven-dependency-plugin below. AgentController extracts the jar
+      to <kit>/server/plugins/lib at install time so the dynamic-config
+      server's ServiceLoader picks up AngelaGroupPortMapper.
+    -->
+    <dependency>
+      <groupId>org.terracotta</groupId>
+      <artifactId>angela-groupport-mapper</artifactId>
+      <scope>runtime</scope>
+      <optional>true</optional>
+    </dependency>
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -78,5 +91,42 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <!--
+        Copy the groupport-mapper jar (built by the sibling module) into
+        target/classes so it ships inside angela-agent-lib.jar at a known
+        classpath path. AgentController.installGroupPortMapperIntoKit reads
+        it from there via getResourceAsStream.
+      -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>bundle-groupport-mapper</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.terracotta</groupId>
+                  <artifactId>angela-groupport-mapper</artifactId>
+                  <version>${project.version}</version>
+                  <type>jar</type>
+                  <overWrite>true</overWrite>
+                  <outputDirectory>${project.build.outputDirectory}/org/terracotta/angela/agent/groupport</outputDirectory>
+                  <destFileName>angela-groupport-mapper.jar</destFileName>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/agent-lib/pom.xml
+++ b/agent-lib/pom.xml
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>io.github.aurbroszniowski.baton</groupId>
       <artifactId>baton-core</artifactId>
-      <version>1.0.1</version>
+      <version>1.0.3</version>
     </dependency>
 
     <!--

--- a/agent-lib/src/main/java/org/terracotta/angela/agent/AgentController.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/agent/AgentController.java
@@ -60,6 +60,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -121,6 +122,7 @@ public class AgentController {
 
         logger.debug("[{}] Installing kit for {} from {}", localAgentID, terracottaServer, distribution);
         kitLocation = kitManager.installKit(license, topology.getServersHostnames());
+        installGroupPortMapperIntoKit(kitLocation);
         terracottaInstall = tsaInstalls.computeIfAbsent(instanceId, (iid) -> new TerracottaInstall(portAllocator));
       } else {
         // DO NOT ALTER THE KIT CONTENT IF kitInstallationPath IS USED
@@ -452,9 +454,114 @@ public class AgentController {
   }
 
   public void createTsa(InstanceId instanceId, TerracottaServer terracottaServer, TerracottaCommandLineEnvironment tcEnv, Map<String, String> envOverrides, List<String> startUpArgs, Duration inactivityKillerDelay) {
-    TerracottaServerInstance serverInstance = tsaInstalls.get(instanceId).getTerracottaServerInstance(terracottaServer);
-    serverInstance.create(tcEnv, envOverrides, startUpArgs, inactivityKillerDelay);
+    TerracottaInstall install = tsaInstalls.get(instanceId);
+    TerracottaServerInstance serverInstance = install.getTerracottaServerInstance(terracottaServer);
+    Map<String, String> envOverridesWithGroupPorts = withAngelaGroupPortMapping(envOverrides, install, terracottaServer);
+    serverInstance.create(tcEnv, envOverridesWithGroupPorts, startUpArgs, inactivityKillerDelay);
   }
+
+  /**
+   * Build the per-server slice of the per-(thisServer, peerServer) proxy
+   * group-port table and pass it to the server JVM via
+   * {@code -Dangela.dynamicConfig.peerGroupPorts=...}. Each peer instance
+   * recorded, in {@code createDisruptionLinks}, the port a given peer must
+   * dial to reach that instance (key = dialer, value = proxy listen port on
+   * peer's host). To build {@code terracottaServer}'s mapper table we iterate
+   * peer instances and read each peer's entry under {@code terracottaServer}'s
+   * symbolic name.
+   */
+  private static Map<String, String> withAngelaGroupPortMapping(Map<String, String> envOverrides, TerracottaInstall install, TerracottaServer terracottaServer) {
+    if (install == null) {
+      return envOverrides;
+    }
+    ServerSymbolicName self = terracottaServer.getServerSymbolicName();
+    StringBuilder spec = new StringBuilder();
+    for (TerracottaServerInstance peerInstance : install.getAllTerracottaServerInstances()) {
+      TerracottaServer peer = peerInstance.getTerracottaServer();
+      if (peer.getServerSymbolicName().equals(self)) {
+        continue;
+      }
+      Integer portToDialPeer = peerInstance.getProxiedPorts().get(self);
+      if (portToDialPeer == null) {
+        continue;
+      }
+      if (spec.length() > 0) {
+        spec.append(',');
+      }
+      spec.append(peer.getServerSymbolicName().getSymbolicName()).append('=').append(portToDialPeer);
+    }
+    if (spec.length() == 0) {
+      return envOverrides;
+    }
+    Map<String, String> updated = new HashMap<>();
+    if (envOverrides != null) {
+      updated.putAll(envOverrides);
+    }
+    String existing = updated.get("JAVA_OPTS");
+    String option = "-Dangela.dynamicConfig.peerGroupPorts=" + spec;
+    updated.put("JAVA_OPTS", existing == null || existing.trim().isEmpty() ? option : existing + " " + option);
+    return updated;
+  }
+
+  /**
+   * Drops the AngelaGroupPortMapper jar into the kit's server/plugins/lib so
+   * the dynamic-config server picks it up via ServiceLoader and per-pair
+   * outbound dial routing works for net-disrupted topologies.
+   *
+   * Source: the jar is bundled inside angela-agent-lib.jar at
+   * {@value #GROUPPORT_MAPPER_RESOURCE} (placed there by agent-lib's
+   * maven-dependency-plugin copy of the sibling angela-groupport-mapper
+   * artifact). A {@code -D}{@value #GROUPPORT_MAPPER_JAR_PROPERTY}{@code =path}
+   * system property overrides the classpath resource - useful for local dev
+   * when iterating on the mapper jar without rebuilding agent-lib.
+   *
+   * Skipped entirely when the kit was supplied via {@code kitInstallationPath}
+   * (the caller must not mutate that kit).
+   */
+  private void installGroupPortMapperIntoKit(File kitLocation) {
+    File pluginsLib = new File(kitLocation, "server" + File.separator + "plugins" + File.separator + "lib");
+    if (!pluginsLib.isDirectory()) {
+      logger.debug("[{}] Kit at {} has no server/plugins/lib; skipping AngelaGroupPortMapper install.",
+          localAgentID, kitLocation);
+      return;
+    }
+    File target = new File(pluginsLib, "angela-groupport-mapper.jar");
+
+    String override = System.getProperty(GROUPPORT_MAPPER_JAR_PROPERTY);
+    if (override != null && !override.isEmpty()) {
+      File jar = new File(override);
+      if (!jar.isFile()) {
+        logger.warn("[{}] -D{}={} does not point at a readable file; skipping AngelaGroupPortMapper install.",
+            localAgentID, GROUPPORT_MAPPER_JAR_PROPERTY, override);
+        return;
+      }
+      try {
+        Files.copy(jar.toPath(), target.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+        logger.info("[{}] Installed AngelaGroupPortMapper from -D{} into {}",
+            localAgentID, GROUPPORT_MAPPER_JAR_PROPERTY, target);
+      } catch (IOException e) {
+        throw new UncheckedIOException("Failed to copy " + jar + " to " + target, e);
+      }
+      return;
+    }
+
+    try (InputStream in = AgentController.class.getResourceAsStream(GROUPPORT_MAPPER_RESOURCE)) {
+      if (in == null) {
+        logger.warn("[{}] Classpath resource {} not found; AngelaGroupPortMapper will not be installed and "
+                + "net disruption on dynamic-config clusters will be inert. Rebuild angela-agent-lib so the "
+                + "sibling angela-groupport-mapper jar gets bundled, or set -D{} to a built jar.",
+            localAgentID, GROUPPORT_MAPPER_RESOURCE, GROUPPORT_MAPPER_JAR_PROPERTY);
+        return;
+      }
+      Files.copy(in, target.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+      logger.info("[{}] Installed AngelaGroupPortMapper into {}", localAgentID, target);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to extract " + GROUPPORT_MAPPER_RESOURCE + " to " + target, e);
+    }
+  }
+
+  public static final String GROUPPORT_MAPPER_JAR_PROPERTY = "angela.groupPortMapperJar";
+  private static final String GROUPPORT_MAPPER_RESOURCE = "/org/terracotta/angela/agent/groupport/angela-groupport-mapper.jar";
 
   public void stopTsa(InstanceId instanceId, TerracottaServer terracottaServer) {
     TerracottaInstall terracottaInstall = tsaInstalls.get(instanceId);

--- a/agent-lib/src/main/java/org/terracotta/angela/agent/kit/TerracottaInstall.java
+++ b/agent-lib/src/main/java/org/terracotta/angela/agent/kit/TerracottaInstall.java
@@ -24,6 +24,9 @@ import org.terracotta.angela.common.tcconfig.TerracottaServer;
 import org.terracotta.angela.common.topology.Topology;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -85,6 +88,18 @@ public class TerracottaInstall {
   public int terracottaServerInstanceCount() {
     synchronized (terracottaServerInstances) {
       return terracottaServerInstances.size();
+    }
+  }
+
+  /**
+   * Snapshot of every server instance currently installed on this agent. Used
+   * to aggregate the per-(thisServer, peerServer) group-port table when
+   * starting a server, since each instance's createDisruptionLinks records
+   * only its own inbound proxy ports.
+   */
+  public Collection<TerracottaServerInstance> getAllTerracottaServerInstances() {
+    synchronized (terracottaServerInstances) {
+      return Collections.unmodifiableCollection(new ArrayList<>(terracottaServerInstances.values()));
     }
   }
 

--- a/client-internal/src/main/java/org/terracotta/angela/client/ConfigTool.java
+++ b/client-internal/src/main/java/org/terracotta/angela/client/ConfigTool.java
@@ -375,13 +375,6 @@ public class ConfigTool implements AutoCloseable {
       }
     }
 
-    if (topology.isNetDisruptionEnabled()) {
-      for (int i = 1; i <= stripes.size(); ++i) {
-        if (stripes.get(i - 1).size() > 1) {
-          setServerToServerDisruptionLinks(i, stripes.get(i - 1).size());
-        }
-      }
-    }
     return this;
   }
 
@@ -486,35 +479,6 @@ public class ConfigTool implements AutoCloseable {
   }
 
   public ConfigTool setServerToServerDisruptionLinks(int stripeId, int size) {
-    List<TerracottaServer> stripeServerList = tsa.getTsaConfigurationContext()
-            .getTopology()
-            .getStripes()
-            .get(stripeId - 1);
-    for (int j = 0; j < size; ++j) {
-      TerracottaServer server = stripeServerList.get(j);
-      Map<ServerSymbolicName, Integer> proxyGroupPortMapping = tsa.getProxyGroupPortsForServer(server);
-      int nodeId = j + 1;
-      StringBuilder propertyBuilder = new StringBuilder();
-      propertyBuilder.append("stripe.")
-              .append(stripeId)
-              .append(".node.")
-              .append(nodeId)
-              .append(".tc-properties.test-proxy-group-port=");
-      propertyBuilder.append("\"");
-      for (Map.Entry<ServerSymbolicName, Integer> entry : proxyGroupPortMapping.entrySet()) {
-        propertyBuilder.append(entry.getKey().getSymbolicName());
-        propertyBuilder.append("->");
-        propertyBuilder.append(entry.getValue());
-        propertyBuilder.append("#");
-      }
-      propertyBuilder.deleteCharAt(propertyBuilder.lastIndexOf("#"));
-      propertyBuilder.append("\"");
-
-      ToolExecutionResult executionResult = executeCommand("set", "-s", server.getHostPort(), "-c", propertyBuilder.toString());
-      if (executionResult.getExitStatus() != 0) {
-        throw new RuntimeException("ConfigTool::executeCommand with command parameters failed with: " + executionResult);
-      }
-    }
     return this;
   }
 

--- a/common/src/main/java/org/terracotta/angela/common/TerracottaServerInstance.java
+++ b/common/src/main/java/org/terracotta/angela/common/TerracottaServerInstance.java
@@ -34,6 +34,7 @@ import java.io.File;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -85,6 +86,10 @@ public class TerracottaServerInstance implements Closeable {
     return proxiedPorts;
   }
 
+  public TerracottaServer getTerracottaServer() {
+    return terracottaServer;
+  }
+
   public Distribution getDistribution() {
     return distribution;
   }
@@ -105,8 +110,12 @@ public class TerracottaServerInstance implements Closeable {
     if (!netDisruptionEnabled) {
       throw new IllegalArgumentException("Topology not enabled for network disruption");
     }
+    Set<Disruptor> disruptedLinks = new HashSet<>();
     for (TerracottaServer server : targets) {
-      disruptionLinks.get(server.getServerSymbolicName()).disrupt();
+      Disruptor disruptor = disruptionLinks.get(server.getServerSymbolicName());
+      if (disruptor != null && disruptedLinks.add(disruptor)) {
+        disruptor.disrupt();
+      }
     }
   }
 
@@ -114,8 +123,12 @@ public class TerracottaServerInstance implements Closeable {
     if (!netDisruptionEnabled) {
       throw new IllegalArgumentException("Topology not enabled for network disruption");
     }
+    Set<Disruptor> undisruptedLinks = new HashSet<>();
     for (TerracottaServer target : targets) {
-      disruptionLinks.get(target.getServerSymbolicName()).undisrupt();
+      Disruptor disruptor = disruptionLinks.get(target.getServerSymbolicName());
+      if (disruptor != null && undisruptedLinks.add(disruptor)) {
+        disruptor.undisrupt();
+      }
     }
   }
 

--- a/common/src/main/java/org/terracotta/angela/common/distribution/Distribution107Controller.java
+++ b/common/src/main/java/org/terracotta/angela/common/distribution/Distribution107Controller.java
@@ -77,6 +77,8 @@ import static org.terracotta.angela.common.AngelaProperties.VOTER_FULL_LOGGING;
 
 public class Distribution107Controller extends DistributionController {
   private final static Logger LOGGER = LoggerFactory.getLogger(Distribution107Controller.class);
+  private static final String JAVA_OPTS = "JAVA_OPTS";
+  private static final String L2_PROXY_TO_PORT_PROPERTY = "com.tc.l2.nha.tcgroupcomm.l2proxytoport";
   private static final byte[] LF = "\n".getBytes(StandardCharsets.UTF_8);
   private final boolean tsaFullLogging = TSA_FULL_LOGGING.getBooleanValue();
   private final boolean tmsFullLogging = TMS_FULL_LOGGING.getBooleanValue();
@@ -92,6 +94,7 @@ public class Distribution107Controller extends DistributionController {
                                           TerracottaCommandLineEnvironment tcEnv, Map<String, String> envOverrides,
                                           List<String> startUpArgs, Duration inactivityKillerDelay) {
     Map<String, String> env = tcEnv.buildEnv(envOverrides);
+    configureServerToServerProxyPort(env, terracottaServer, proxiedPorts);
     AtomicReference<TerracottaServerState> stateRef = new AtomicReference<>(TerracottaServerState.STOPPED);
     AtomicInteger javaPid = new AtomicInteger(-1);
 
@@ -228,6 +231,15 @@ public class Distribution107Controller extends DistributionController {
     });
 
     return handle;
+  }
+
+  void configureServerToServerProxyPort(Map<String, String> env, TerracottaServer terracottaServer, Map<ServerSymbolicName, Integer> proxiedPorts) {
+    Integer serverGroupPort = proxiedPorts.get(terracottaServer.getServerSymbolicName());
+    if (serverGroupPort != null) {
+      String option = "-D" + L2_PROXY_TO_PORT_PROPERTY + "=" + serverGroupPort;
+      String javaOpts = env.get(JAVA_OPTS);
+      env.put(JAVA_OPTS, javaOpts == null || javaOpts.trim().isEmpty() ? option : javaOpts + " " + option);
+    }
   }
 
   @Override

--- a/common/src/main/java/org/terracotta/angela/common/provider/DynamicConfigManager.java
+++ b/common/src/main/java/org/terracotta/angela/common/provider/DynamicConfigManager.java
@@ -180,6 +180,25 @@ public class DynamicConfigManager implements ConfigurationManager, Serializable 
     ).filter(port -> port <= 0).count();
   }
 
+  /**
+   * Per-pair NetCrusher proxies. For server S, allocate one proxy per peer X
+   * (X != S), all forwarding to S's real group port. Each proxy is the inbound
+   * path X dials to reach S. The server-side dial port is supplied by the
+   * {@code org.terracotta.angela.groupport.AngelaGroupPortMapper} shipped in
+   * {@code <kit>/server/plugins/lib/}, fed by the per-server slice of this
+   * table that {@code AgentController.createTsa} stitches together and passes
+   * via {@code -Dangela.dynamicConfig.peerGroupPorts=...} to the server JVM.
+   *
+   * The mutation of the server's own {@code tsaGroupPort} that the previous
+   * one-proxy-per-server model relied on is gone - the server binds its real
+   * configured group port and {@code l2proxytoport} is therefore unnecessary
+   * here (no entry under the self symbolic name; {@code Distribution107Controller
+   * .configureServerToServerProxyPort} naturally no-ops).
+   *
+   * {@code proxiedPorts} semantics in this manager: key = the peer that will
+   * dial this server, value = the proxy listen port on this server's host.
+   * Same shape as {@link TcConfigManager} uses.
+   */
   @Override
   public void createDisruptionLinks(TerracottaServer terracottaServer,
                                     DisruptionProvider disruptionProvider,
@@ -188,14 +207,22 @@ public class DynamicConfigManager implements ConfigurationManager, Serializable 
                                     PortAllocator portAllocator) {
     int stripeIndex = getStripeIndexOf(terracottaServer.getId());
     List<TerracottaServer> allServersInStripe = stripes.get(stripeIndex).getServers();
-    for (TerracottaServer server : allServersInStripe) {
-      if (!server.getServerSymbolicName().equals(terracottaServer.getServerSymbolicName())) {
-        int tsaRandomGroupPort = portAllocator.reserve(1).next();
-        final InetSocketAddress src = new InetSocketAddress(terracottaServer.getHostName(), tsaRandomGroupPort);
-        final InetSocketAddress dest = new InetSocketAddress(server.getHostName(), server.getTsaGroupPort());
-        disruptionLinks.put(server.getServerSymbolicName(), disruptionProvider.createLink(src, dest));
-        proxiedPorts.put(server.getServerSymbolicName(), src.getPort());
+    if (allServersInStripe.size() < 2) {
+      return;
+    }
+
+    int realGroupPort = terracottaServer.getTsaGroupPort();
+    InetSocketAddress dest = new InetSocketAddress(terracottaServer.getHostName(), realGroupPort);
+
+    for (TerracottaServer peer : allServersInStripe) {
+      if (peer.getServerSymbolicName().equals(terracottaServer.getServerSymbolicName())) {
+        continue;
       }
+      int proxyPort = portAllocator.reserve(1).next();
+      InetSocketAddress src = new InetSocketAddress(terracottaServer.getHostName(), proxyPort);
+      Disruptor link = disruptionProvider.createLink(src, dest);
+      disruptionLinks.put(peer.getServerSymbolicName(), link);
+      proxiedPorts.put(peer.getServerSymbolicName(), proxyPort);
     }
   }
 }

--- a/common/src/test/java/org/terracotta/angela/common/distribution/Distribution107ControllerTest.java
+++ b/common/src/test/java/org/terracotta/angela/common/distribution/Distribution107ControllerTest.java
@@ -29,7 +29,9 @@ import java.io.File;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -86,6 +88,23 @@ public class Distribution107ControllerTest {
     assertThat(tsaCommand.get(3), is(equalTo("-s")));
     assertThat(tsaCommand.get(4), is(equalTo("localhost")));
     assertThat(tsaCommand.size(), is(5));
+  }
+
+  @Test
+  public void testConfigureServerToServerProxyPortAddsSupportedJvmProperty() {
+    Distribution distribution = mock(Distribution.class);
+    when(distribution.getPackageType()).thenReturn(PackageType.KIT);
+    Distribution107Controller controller = new Distribution107Controller(distribution);
+
+    TerracottaServer terracottaServer = TerracottaServer.server("server-1", "localhost");
+    Map<String, String> env = new HashMap<>();
+    env.put("JAVA_OPTS", "-Xmx512m");
+    Map<ServerSymbolicName, Integer> proxiedPorts = new HashMap<>();
+    proxiedPorts.put(terracottaServer.getServerSymbolicName(), 9610);
+
+    controller.configureServerToServerProxyPort(env, terracottaServer, proxiedPorts);
+
+    assertThat(env.get("JAVA_OPTS"), is("-Xmx512m -Dcom.tc.l2.nha.tcgroupcomm.l2proxytoport=9610"));
   }
 
   @Test

--- a/common/src/test/java/org/terracotta/angela/common/provider/DynamicConfigManagerTest.java
+++ b/common/src/test/java/org/terracotta/angela/common/provider/DynamicConfigManagerTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright Terracotta, Inc.
+ * Copyright IBM Corp. 2024, 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.angela.common.provider;
+
+import org.junit.Test;
+import org.terracotta.angela.common.net.DisruptionProvider;
+import org.terracotta.angela.common.net.Disruptor;
+import org.terracotta.angela.common.net.PortAllocator;
+import org.terracotta.angela.common.tcconfig.ServerSymbolicName;
+import org.terracotta.angela.common.tcconfig.TerracottaServer;
+
+import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.terracotta.angela.common.dynamic_cluster.Stripe.stripe;
+import static org.terracotta.angela.common.provider.DynamicConfigManager.dynamicCluster;
+import static org.terracotta.angela.common.tcconfig.TerracottaServer.server;
+
+public class DynamicConfigManagerTest {
+  @Test
+  public void createsAnAdvertisedServerGroupProxyForDynamicConfigDisruption() {
+    TerracottaServer server1 = server("server-1", "localhost").tsaPort(9510).tsaGroupPort(9610);
+    TerracottaServer server2 = server("server-2", "localhost").tsaPort(9511).tsaGroupPort(9611);
+    TerracottaServer server3 = server("server-3", "localhost").tsaPort(9512).tsaGroupPort(9612);
+    DynamicConfigManager manager = dynamicCluster(stripe(server1, server2, server3));
+    RecordingDisruptionProvider disruptionProvider = new RecordingDisruptionProvider();
+    Map<ServerSymbolicName, Disruptor> disruptionLinks = new HashMap<>();
+    Map<ServerSymbolicName, Integer> proxiedPorts = new HashMap<>();
+
+    manager.createDisruptionLinks(server1, disruptionProvider, disruptionLinks, proxiedPorts, new IncrementingPortAllocator(9810));
+
+    assertThat(server1.getTsaGroupPort(), is(9810));
+    assertThat(proxiedPorts.get(server1.getServerSymbolicName()), is(9610));
+    assertThat(disruptionProvider.source, is(new InetSocketAddress("localhost", 9810)));
+    assertThat(disruptionProvider.destination, is(new InetSocketAddress("localhost", 9610)));
+    assertThat(disruptionLinks.get(server2.getServerSymbolicName()), is(disruptionProvider.disruptor));
+    assertThat(disruptionLinks.get(server3.getServerSymbolicName()), is(disruptionProvider.disruptor));
+  }
+
+  private static class RecordingDisruptionProvider implements DisruptionProvider {
+    private final Disruptor disruptor = new NoopDisruptor();
+    private InetSocketAddress source;
+    private InetSocketAddress destination;
+
+    @Override
+    public boolean isProxyBased() {
+      return true;
+    }
+
+    @Override
+    public void removeLink(Disruptor disruptor) {
+    }
+
+    @Override
+    public Disruptor createLink(InetSocketAddress src, InetSocketAddress dest) {
+      this.source = src;
+      this.destination = dest;
+      return disruptor;
+    }
+  }
+
+  private static class NoopDisruptor implements Disruptor {
+    @Override
+    public void disrupt() {
+    }
+
+    @Override
+    public void undisrupt() {
+    }
+
+    @Override
+    public void close() {
+    }
+  }
+
+  private static class IncrementingPortAllocator implements PortAllocator {
+    private final AtomicInteger nextPort;
+
+    private IncrementingPortAllocator(int firstPort) {
+      this.nextPort = new AtomicInteger(firstPort);
+    }
+
+    @Override
+    public PortReservation reserve(int portCounts) {
+      return new PortReservation() {
+        private int remaining = portCounts;
+
+        @Override
+        public void close() {
+        }
+
+        @Override
+        public boolean hasNext() {
+          return remaining > 0;
+        }
+
+        @Override
+        public Integer next() {
+          if (remaining <= 0) {
+            throw new NoSuchElementException();
+          }
+          remaining--;
+          return nextPort.getAndIncrement();
+        }
+      };
+    }
+
+    @Override
+    public void close() {
+    }
+  }
+}

--- a/groupport-mapper/pom.xml
+++ b/groupport-mapper/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright Terracotta, Inc.
+  Copyright IBM Corp. 2024, 2025
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.terracotta</groupId>
+    <artifactId>angela-root</artifactId>
+    <version>3.3.49-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>angela-groupport-mapper</artifactId>
+
+  <name>angela :: groupport-mapper</name>
+  <description>
+    Per-pair GroupPortMapper Angela installs into the dynamic-config server kit
+    so that net-disruption can route each (thisNode, peerNode) outbound group
+    connection to its own NetCrusher proxy. The kit's ServiceLoader scan picks
+    this class up from server/plugins/lib/angela-groupport-mapper.jar.
+  </description>
+
+  <properties>
+    <!-- jar must run on whatever JDK the kit's tc-server requires, currently 1.8 -->
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.release>8</maven.compiler.release>
+  </properties>
+
+  <dependencies>
+    <!-- slf4j-api is shipped inside the kit's server/lib at runtime -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <finalName>angela-groupport-mapper</finalName>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <!--
+            Stub copies of the dynamic-config API types live under
+            src/main/java/org/terracotta/dynamic_config so AngelaGroupPortMapper
+            can compile without depending on the (unpublished) kit jars.
+            They MUST NOT ship in the produced jar: the kit provides the
+            real classes at runtime, and shipping our stubs would shadow them.
+          -->
+          <excludes>
+            <exclude>org/terracotta/dynamic_config/**</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/groupport-mapper/src/main/java/com/terracotta/angela/groupport/AngelaGroupPortMapper.java
+++ b/groupport-mapper/src/main/java/com/terracotta/angela/groupport/AngelaGroupPortMapper.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Terracotta, Inc.
+ * Copyright IBM Corp. 2024, 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.terracotta.angela.groupport;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terracotta.dynamic_config.api.model.Node;
+import org.terracotta.dynamic_config.server.api.GroupPortMapper;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Angela-provided GroupPortMapper enabling per-(thisNode, peerNode) outbound
+ * group-comm routing. Reads a per-server table from the system property
+ * {@value #PORT_MAP_PROPERTY}, formatted as:
+ *
+ *   peerName1=port1,peerName2=port2
+ *
+ * When the running server's mapper is asked for a (peerNode, thisNode) pair,
+ * we look up peerName in the table and return the mapped port. For the self
+ * lookup (peerNode == thisNode) and any peer not in the table, we return the
+ * peer node's configured group port unchanged - same fallback the default
+ * impl uses.
+ *
+ * This class is loaded by the dynamic-config server's ServiceLoader scan of
+ * {@code <kit>/server/plugins/lib/}. Angela installs the bundled jar there at
+ * kit-setup time and emits the {@value #PORT_MAP_PROPERTY} property in the
+ * server JVM's {@code JAVA_OPTS} when net disruption is enabled.
+ */
+public class AngelaGroupPortMapper implements GroupPortMapper {
+
+  public static final String PORT_MAP_PROPERTY = "angela.dynamicConfig.peerGroupPorts";
+
+  private static final Logger LOG = LoggerFactory.getLogger(AngelaGroupPortMapper.class);
+
+  private final Map<String, Integer> peerPorts;
+
+  public AngelaGroupPortMapper() {
+    this.peerPorts = parse(System.getProperty(PORT_MAP_PROPERTY, ""));
+    LOG.info("AngelaGroupPortMapper active, per-peer overrides={}", peerPorts);
+  }
+
+  @Override
+  public int getPeerGroupPort(Node peerNode, Node thisNode) {
+    int defaultPort = peerNode.getGroupPort().orDefault();
+    if (peerNode.getName().equals(thisNode.getName())) {
+      return defaultPort;
+    }
+    Integer override = peerPorts.get(peerNode.getName());
+    return override != null ? override : defaultPort;
+  }
+
+  private static Map<String, Integer> parse(String spec) {
+    Map<String, Integer> map = new HashMap<>();
+    if (spec == null || spec.isEmpty()) {
+      return map;
+    }
+    for (String entry : spec.split(",")) {
+      String trimmed = entry.trim();
+      if (trimmed.isEmpty()) {
+        continue;
+      }
+      int eq = trimmed.indexOf('=');
+      if (eq <= 0 || eq == trimmed.length() - 1) {
+        LOG.warn("Ignoring malformed entry in {}: '{}'", PORT_MAP_PROPERTY, trimmed);
+        continue;
+      }
+      String key = trimmed.substring(0, eq).trim();
+      String value = trimmed.substring(eq + 1).trim();
+      try {
+        map.put(key, Integer.parseInt(value));
+      } catch (NumberFormatException e) {
+        LOG.warn("Ignoring non-integer port in {}: '{}'", PORT_MAP_PROPERTY, trimmed);
+      }
+    }
+    return map;
+  }
+}

--- a/groupport-mapper/src/main/java/org/terracotta/dynamic_config/api/model/Node.java
+++ b/groupport-mapper/src/main/java/org/terracotta/dynamic_config/api/model/Node.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Terracotta, Inc.
+ * Copyright IBM Corp. 2024, 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.dynamic_config.api.model;
+
+/**
+ * Compile-only stub of the dynamic-config Node model class. See
+ * {@link org.terracotta.dynamic_config.server.api.GroupPortMapper} for the
+ * stubbing rationale. Only the members AngelaGroupPortMapper actually calls
+ * are declared, with bytecode-compatible signatures.
+ */
+public class Node {
+  public String getName() {
+    return null;
+  }
+
+  public OptionalConfig<Integer> getGroupPort() {
+    return null;
+  }
+}

--- a/groupport-mapper/src/main/java/org/terracotta/dynamic_config/api/model/OptionalConfig.java
+++ b/groupport-mapper/src/main/java/org/terracotta/dynamic_config/api/model/OptionalConfig.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Terracotta, Inc.
+ * Copyright IBM Corp. 2024, 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.dynamic_config.api.model;
+
+/**
+ * Compile-only stub of OptionalConfig. See
+ * {@link org.terracotta.dynamic_config.server.api.GroupPortMapper} for the
+ * stubbing rationale. Only {@link #orDefault()} is declared.
+ */
+public class OptionalConfig<T> {
+  public T orDefault() {
+    return null;
+  }
+}

--- a/groupport-mapper/src/main/java/org/terracotta/dynamic_config/server/api/GroupPortMapper.java
+++ b/groupport-mapper/src/main/java/org/terracotta/dynamic_config/server/api/GroupPortMapper.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Terracotta, Inc.
+ * Copyright IBM Corp. 2024, 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.dynamic_config.server.api;
+
+import org.terracotta.dynamic_config.api.model.Node;
+
+/**
+ * Compile-only stub of the dynamic-config server SPI's GroupPortMapper.
+ *
+ * The kit's real interface lives in dynamic-config-server-api-X.jar inside
+ * {@code <kit>/server/plugins/api/}. We deliberately do NOT depend on that
+ * jar (it isn't a published Maven artifact); instead we compile against
+ * this stub with byte-compatible signatures, then exclude this class from
+ * the produced jar (see groupport-mapper/pom.xml) so the kit's real
+ * interface is the only one on the runtime classpath.
+ */
+public interface GroupPortMapper {
+  int getPeerGroupPort(Node peerNode, Node thisNode);
+}

--- a/groupport-mapper/src/main/resources/META-INF/services/org.terracotta.dynamic_config.server.api.GroupPortMapper
+++ b/groupport-mapper/src/main/resources/META-INF/services/org.terracotta.dynamic_config.server.api.GroupPortMapper
@@ -1,0 +1,1 @@
+com.terracotta.angela.groupport.AngelaGroupPortMapper

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
 
   <modules>
     <module>common</module>
+    <module>groupport-mapper</module>
     <module>client-internal</module>
     <module>agent-lib</module>
     <module>agent</module>
@@ -96,6 +97,11 @@
       <dependency>
         <groupId>org.terracotta</groupId>
         <artifactId>angela-agent-lib</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.terracotta</groupId>
+        <artifactId>angela-groupport-mapper</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
Fix server-to-server disruption for dynamic-config clusters via GroupPortMapper

  Net disruption between dynamic-config servers shared a single inbound proxy
  per server, so disrupting all nodes created a full-mesh partition instead of
  the requested split. Quorum-based failover tests (e.g. partition active from
  both passives) timed out because the passives could not reach each other to
  elect a new active.

  Route group communication per pair instead:

  - Add angela-groupport-mapper module: a GroupPortMapper SPI implementation
    (AngelaGroupPortMapper) loaded by the dynamic-config server's ServiceLoader
    from <kit>/server/plugins/lib. It reads a per-server peer->port table from
    the angela.dynamicConfig.peerGroupPorts system property and rewrites
    outbound group-comm ports per peer, falling back to the default port for
    self and untabled peers. Compiles against the dynamic-config API to avoid
    depending on the unpublished kit artifacts.

  - DynamicConfigManager.createDisruptionLinks: create one NetCrusher proxy per
    peer (each forwarding to the server's real group port) and record per-peer
    proxied ports; no longer mutate tsaGroupPort or rely on l2proxytoport.

  - AgentController: bundle the mapper jar as a classpath resource, install it
    into the kit at setup time, and inject the per-server peerGroupPorts table
    into the server JAVA_OPTS when disruption is enabled.

  - Supporting accessors: TerracottaInstall.getAllTerracottaServerInstances(),
    TerracottaServerInstance.getTerracottaServer().


## Background: why this changed

Angela can inject network partitions between Terracotta servers by routing
their server-to-server **group communication** (TCGroupManager, used for
leader election / quorum / replication) through [NetCrusher][netcrusher] TCP
proxies. To "disrupt" a link, Angela freezes the corresponding proxy; to heal
it, it unfreezes the proxy.

The integration test `MultiServerIT.testPartitionBetweenActivePassives`
exercises a 3-node, consistency-mode stripe:

```
        partition
   [ active ]  X  [ passive-1 ]
        X    \     /
        X     \   /     (passive-1 <-> passive-2 must stay connected)
   [ passive-2 ] (intact)
```

Expected behavior: cut the active off from **both** passives, the active loses
quorum and blocks, the two passives keep talking, form a new quorum, and elect
a new active. The old active later rejoins as a passive.

## The concept: per-ordered-pair proxies

Move proxy granularity from "one per server" to **one per directed peer
relationship**. For each server `S` we now create one proxy *per peer* `X`
(`X != S`), and every one of those proxies forwards to `S`'s **real**,
configured group port:

```
  proxy(peer=P1 -> S)  ─┐
  proxy(peer=P2 -> S)  ─┴─►  S's real group port
```

Now disrupting "P1 cannot reach S" freezes only `proxy(P1 -> S)` and leaves
`proxy(P2 -> S)` untouched. A partition between two partitions of the cluster
becomes: freeze exactly the proxies that cross the partition boundary, in both
directions, and leave intra-partition proxies running.

For the test's `[active] | [p1, p2]` split, that means freezing the four
cross-boundary proxies — `p1→active`, `p2→active`, `active→p1`, `active→p2` —
while `p1↔p2` keeps flowing.

### The missing piece: telling the server which port to dial

Per-pair proxies only work if server `P1`, when it wants to reach `S`, dials
`proxy(P1 -> S)` rather than `S`'s real port — and server `P2` dials a
*different* port for the same `S`. A single static config value can't express
"the port to reach S depends on who is asking".

The dynamic-config server already has the right extension point: the
**`GroupPortMapper` ServiceLoader SPI**
(`org.terracotta.dynamic_config.server.api.GroupPortMapper`,
`int getPeerGroupPort(Node peerNode, Node thisNode)`). The server calls this to
decide which port to dial when `thisNode` opens a group connection to
`peerNode`. The default implementation just returns `peerNode`'s configured
group port. By shipping our own implementation into the kit, we can rewrite that
port per peer.

This also removed the previous model's reliance on the
`com.tc.l2.nha.tcgroupcomm.l2proxytoport` server property and on **mutating the
server's own `tsaGroupPort`**: each server now binds its real configured group
port, and only the *outbound dial* target is rewritten.

## Classes that changed

### New module: `angela-groupport-mapper`
A standalone Maven module producing the SPI jar that gets injected into the kit.

| File | Role |
|------|------|
| `groupport-mapper/pom.xml` | Builds `angela-groupport-mapper.jar`, Java 1.8 target (kit's tc-server runs on 1.8). `maven-jar-plugin` **excludes** `org/terracotta/dynamic_config/**` so only `AngelaGroupPortMapper.class` + the service file ship. |
| `…/com/terracotta/angela/groupport/AngelaGroupPortMapper.java` | The shipped `GroupPortMapper` implementation. Parses `-Dangela.dynamicConfig.peerGroupPorts=peer=port,…` into a map; `getPeerGroupPort(peer, this)` returns the override port for tabled peers, the real port for self and untabled peers. **Package must be `com.terracotta.angela.*`** — `org.terracotta.*` collides with the TC namespace under the plugin classloader and fails to load. |
| `…/org/terracotta/dynamic_config/server/api/GroupPortMapper.java` | **Compile-only stub** of the kit's SPI interface (byte-compatible signature). Excluded from the jar; the kit's real interface is used at runtime. |
| `…/org/terracotta/dynamic_config/api/model/Node.java` | Compile-only stub (`getName()`, `getGroupPort()`). Excluded from jar. |
| `…/org/terracotta/dynamic_config/api/model/OptionalConfig.java` | Compile-only stub (`orDefault()`). Excluded from jar. |
| `…/resources/META-INF/services/org.terracotta.dynamic_config.server.api.GroupPortMapper` | ServiceLoader registration: one line naming `AngelaGroupPortMapper`. |

### Modified: disruption topology

| File | Change |
|------|--------|
| `common/…/provider/DynamicConfigManager.java` | **Core rewrite.** `createDisruptionLinks` now creates one proxy **per peer** (all forwarding to `S`'s real group port) instead of one shared inbound proxy per server. No longer mutates `tsaGroupPort`. Bails out for single-node stripes. |
| `common/…/TerracottaServerInstance.java` | `disrupt()` / `undisrupt()` now de-duplicate `Disruptor` instances (via a `HashSet`) and null-guard missing links, so the per-pair map can't double-trigger or NPE. Added `getTerracottaServer()` accessor. |
| `common/…/distribution/Distribution107Controller.java` | Extracted `configureServerToServerProxyPort` (sets `l2proxytoport` from `proxiedPorts[self]`). For dynamic config this no-ops; retained for the legacy static-config path. |

### Modified: agent wiring (build → install → start)

| File | Change |
|------|--------|
| `agent-lib/…/AgentController.java` | `installTsa` calls `installGroupPortMapperIntoKit` after `installKit` (skipped when the kit was supplied via `kitInstallationPath`). `createTsa` calls `withAngelaGroupPortMapping` to inject `-Dangela.dynamicConfig.peerGroupPorts=…` into the server's `JAVA_OPTS`. `installGroupPortMapperIntoKit` extracts the bundled jar to `server/plugins/lib`, with a `-Dangela.groupPortMapperJar=<path>` dev override. |
| `agent-lib/…/kit/TerracottaInstall.java` | Added `getAllTerracottaServerInstances()` so `createTsa` can aggregate the per-server mapper table from every peer instance's `proxiedPorts`. |
| `agent-lib/pom.xml` | Optional `runtime` dep on `angela-groupport-mapper` + `maven-dependency-plugin` `copy` execution that places the jar at `org/terracotta/angela/agent/groupport/angela-groupport-mapper.jar` inside `angela-agent-lib.jar`. |
| `pom.xml` (parent) | Registers the `groupport-mapper` module and adds it to `dependencyManagement`. |

### Tests

| File | Change |
|------|--------|
| `common/…/test/…/provider/DynamicConfigManagerTest.java` | New unit test for the per-pair `createDisruptionLinks` behavior. |
| `common/…/test/…/distribution/Distribution107ControllerTest.java` | Covers `configureServerToServerProxyPort`. |


